### PR TITLE
Support custom vendor strings.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -53,6 +53,8 @@ fn write_host_rs(mut out: File, triple: Triple) -> io::Result<()> {
     writeln!(out, "use crate::Aarch64Architecture::*;")?;
     writeln!(out, "#[allow(unused_imports)]")?;
     writeln!(out, "use crate::ArmArchitecture::*;")?;
+    writeln!(out, "#[allow(unused_imports)]")?;
+    writeln!(out, "use crate::CustomVendor;")?;
     writeln!(out)?;
     writeln!(out, "/// The `Triple` of the current host.")?;
     writeln!(out, "pub const HOST: Triple = Triple {{")?;
@@ -139,7 +141,11 @@ fn write_host_rs(mut out: File, triple: Triple) -> io::Result<()> {
         "            architecture: Architecture::{:?},",
         triple.architecture
     )?;
-    writeln!(out, "            vendor: Vendor::{:?},", triple.vendor)?;
+    writeln!(
+        out,
+        "            vendor: {},",
+        vendor_display(&triple.vendor)
+    )?;
     writeln!(
         out,
         "            operating_system: OperatingSystem::{:?},",
@@ -164,9 +170,10 @@ fn write_host_rs(mut out: File, triple: Triple) -> io::Result<()> {
 
 fn vendor_display(vendor: &Vendor) -> String {
     match vendor {
-        Vendor::Custom(custom) => {
-            format!("Vendor::Custom(Box::new(String::from_str({:?})))", custom)
-        }
+        Vendor::Custom(custom) => format!(
+            "Vendor::Custom(CustomVendor::Static({:?}))",
+            custom.as_str()
+        ),
         known => format!("Vendor::{:?}", known),
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -32,6 +32,7 @@ mod parse_error {
     }
 }
 
+use self::targets::Vendor;
 use self::triple::Triple;
 
 fn main() {
@@ -60,7 +61,7 @@ fn write_host_rs(mut out: File, triple: Triple) -> io::Result<()> {
         "    architecture: Architecture::{:?},",
         triple.architecture
     )?;
-    writeln!(out, "    vendor: Vendor::{:?},", triple.vendor)?;
+    writeln!(out, "    vendor: {},", vendor_display(&triple.vendor))?;
     writeln!(
         out,
         "    operating_system: OperatingSystem::{:?},",
@@ -90,7 +91,7 @@ fn write_host_rs(mut out: File, triple: Triple) -> io::Result<()> {
     writeln!(out, "impl Vendor {{")?;
     writeln!(out, "    /// Return the vendor for the current host.")?;
     writeln!(out, "    pub const fn host() -> Self {{")?;
-    writeln!(out, "        Vendor::{:?}", triple.vendor)?;
+    writeln!(out, "        {}", vendor_display(&triple.vendor))?;
     writeln!(out, "    }}")?;
     writeln!(out, "}}")?;
     writeln!(out)?;
@@ -159,4 +160,13 @@ fn write_host_rs(mut out: File, triple: Triple) -> io::Result<()> {
     writeln!(out, "}}")?;
 
     Ok(())
+}
+
+fn vendor_display(vendor: &Vendor) -> String {
+    match vendor {
+        Vendor::Custom(custom) => {
+            format!("Vendor::Custom(Box::new(String::from_str({:?})))", custom)
+        }
+        known => format!("Vendor::{:?}", known),
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ mod triple;
 pub use self::host::HOST;
 pub use self::parse_error::ParseError;
 pub use self::targets::{
-    Aarch64Architecture, Architecture, ArmArchitecture, BinaryFormat, Environment, OperatingSystem,
-    Vendor,
+    Aarch64Architecture, Architecture, ArmArchitecture, BinaryFormat, CustomVendor, Environment,
+    OperatingSystem, Vendor,
 };
 pub use self::triple::{CallingConvention, Endianness, PointerWidth, Triple};

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -1246,6 +1246,10 @@ mod tests {
             Triple::from_str("x86_64-custom‍vendor-linux").is_err(),
             "zero-width character hazard"
         );
+        assert!(
+            Triple::from_str("x86_64-﻿customvendor-linux").is_err(),
+            "BOM hazard"
+        );
 
         // Test some valid cases.
         let t = Triple::from_str("x86_64-customvendor-linux")

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -813,10 +813,9 @@ impl FromStr for Vendor {
                 }
 
                 // Restrict the set of characters permitted in a custom vendor.
-                fn is_prohibited_char(c: char) -> bool {
+                if custom.chars().any(|c: char| {
                     !(c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == '.')
-                }
-                if custom.chars().any(is_prohibited_char) {
+                }) {
                     return Err(());
                 }
 

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -1174,6 +1174,7 @@ mod tests {
 
     #[test]
     fn custom_vendors() {
+        // Test various invalid cases.
         assert!(Triple::from_str("x86_64--linux").is_err());
         assert!(Triple::from_str("x86_64-42-linux").is_err());
         assert!(Triple::from_str("x86_64-__customvendor__-linux").is_err());
@@ -1190,6 +1191,31 @@ mod tests {
         assert!(Triple::from_str("x86_64-").is_err());
         assert!(Triple::from_str("x86_64--").is_err());
 
+        // Test various Unicode things.
+        assert!(
+            Triple::from_str("x86_64-𝓬𝓾𝓼𝓽𝓸𝓶𝓿𝓮𝓷𝓭𝓸𝓻-linux").is_err(),
+            "unicode font hazard"
+        );
+        assert!(
+            Triple::from_str("x86_64-ćúśtőḿvéńdőŕ-linux").is_err(),
+            "diacritical mark stripping hazard"
+        );
+        assert!(
+            Triple::from_str("x86_64-customvendοr-linux").is_err(),
+            "homoglyph hazard"
+        );
+        assert!(Triple::from_str("x86_64-customvendor-linux").is_ok());
+        assert!(
+            Triple::from_str("x86_64-ﬃ-linux").is_err(),
+            "normalization hazard"
+        );
+        assert!(Triple::from_str("x86_64-ffi-linux").is_ok());
+        assert!(
+            Triple::from_str("x86_64-custom‍vendor-linux").is_err(),
+            "zero-width character hazard"
+        );
+
+        // Test some valid cases.
         let t = Triple::from_str("x86_64-customvendor-linux")
             .expect("can't parse target with custom vendor");
         assert_eq!(t.architecture, Architecture::X86_64);
@@ -1202,8 +1228,8 @@ mod tests {
         assert_eq!(t.binary_format, BinaryFormat::Elf);
         assert_eq!(t.to_string(), "x86_64-customvendor-linux");
 
-        let t = Triple::from_str("x86_64-customvendor")
-            .expect("can't parse target with custom vendor");
+        let t =
+            Triple::from_str("x86_64-customvendor").expect("can't parse target with custom vendor");
         assert_eq!(t.architecture, Architecture::X86_64);
         assert_eq!(
             t.vendor,

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -779,12 +779,9 @@ impl FromStr for Vendor {
                 }
 
                 // Restrict the set of characters permitted in a custom vendor.
-                if custom
-                    .find(|c: char| {
-                        !(c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == '.')
-                    })
-                    .is_some()
-                {
+                if custom.chars().any(|c: char| {
+                    !(c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == '.')
+                }) {
                     return Err(());
                 }
 

--- a/src/triple.rs
+++ b/src/triple.rs
@@ -323,10 +323,6 @@ mod tests {
             Err(ParseError::UnrecognizedArchitecture("foo".to_owned()))
         );
         assert_eq!(
-            Triple::from_str("unknown-foo"),
-            Err(ParseError::UnrecognizedVendor("foo".to_owned()))
-        );
-        assert_eq!(
             Triple::from_str("unknown-unknown-foo"),
             Err(ParseError::UnrecognizedOperatingSystem("foo".to_owned()))
         );


### PR DESCRIPTION
Add support for custom vendors, as in "x86_64-gentoo-linux-musl".

Fixes #33.