### PR TITLE
Add a wasm64 target.

### DIFF
--- a/src/targets.rs
+++ b/src/targets.rs
@@ -47,6 +47,7 @@ pub enum Architecture {
     Sparc64,
     Sparcv9,
     Wasm32,
+    Wasm64,
     X86_64,
 }
 
@@ -464,6 +465,7 @@ impl Architecture {
             | Architecture::Riscv64gc
             | Architecture::Riscv64imac
             | Architecture::Wasm32
+            | Architecture::Wasm64
             | Architecture::X86_64 => Ok(Endianness::Little),
             Architecture::Mips
             | Architecture::Mips64
@@ -515,7 +517,8 @@ impl Architecture {
             | Architecture::Powerpc64
             | Architecture::S390x
             | Architecture::Sparc64
-            | Architecture::Sparcv9 => Ok(PointerWidth::U64),
+            | Architecture::Sparcv9
+            | Architecture::Wasm64 => Ok(PointerWidth::U64),
         }
     }
 }
@@ -537,7 +540,7 @@ pub(crate) fn default_binary_format(triple: &Triple) -> BinaryFormat {
         | OperatingSystem::VxWorks
         | OperatingSystem::Wasi
         | OperatingSystem::Unknown => match triple.architecture {
-            Architecture::Wasm32 => BinaryFormat::Wasm,
+            Architecture::Wasm32 | Architecture::Wasm64 => BinaryFormat::Wasm,
             _ => BinaryFormat::Unknown,
         },
         _ => BinaryFormat::Elf,
@@ -638,6 +641,7 @@ impl fmt::Display for Architecture {
             Architecture::Sparc64 => f.write_str("sparc64"),
             Architecture::Sparcv9 => f.write_str("sparcv9"),
             Architecture::Wasm32 => f.write_str("wasm32"),
+            Architecture::Wasm64 => f.write_str("wasm64"),
             Architecture::X86_64 => f.write_str("x86_64"),
         }
     }
@@ -742,6 +746,7 @@ impl FromStr for Architecture {
             "sparc64" => Architecture::Sparc64,
             "sparcv9" => Architecture::Sparcv9,
             "wasm32" => Architecture::Wasm32,
+            "wasm64" => Architecture::Wasm64,
             "x86_64" => Architecture::X86_64,
             _ => {
                 if let Ok(arm) = ArmArchitecture::from_str(s) {
@@ -1159,7 +1164,9 @@ mod tests {
             "wasm32-experimental-emscripten",
             "wasm32-unknown-emscripten",
             "wasm32-unknown-unknown",
+            "wasm64-unknown-unknown",
             "wasm32-wasi",
+            "wasm64-wasi",
             "x86_64-apple-darwin",
             "x86_64-apple-ios",
             "x86_64-fortanix-unknown-sgx",


### PR DESCRIPTION
wasm64 is an early prototyping phase, but the name of the target is
sufficiently stable that we can add it here.

See also https://github.com/WebAssembly/design/issues/1325.