### PR TITLE
[WIP] Start on adding C type sizes

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -12,6 +12,10 @@ use std::str::FromStr;
 extern crate alloc;
 
 // Include triple.rs and targets.rs so we can parse the TARGET environment variable.
+// targets.rs depends on data_model
+mod data_model {
+    include!("src/data_model.rs");
+}
 mod triple {
     include!("src/triple.rs");
 }

--- a/src/data_model.rs
+++ b/src/data_model.rs
@@ -37,7 +37,7 @@ impl Size {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum CDataModel {
-    /// The data model used most commonly on Win16. `int` and `long` are 32 bits.
+    /// The data model used most commonly on Win16. `long` and `pointer` are 32 bits.
     LP32,
     /// The data model used most commonly on Win32 and 32-bit Unix systems.
     ///

--- a/src/data_model.rs
+++ b/src/data_model.rs
@@ -1,0 +1,94 @@
+/// The size in bits of a type.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[allow(missing_docs)]
+pub enum Size {
+    U16,
+    U32,
+    U64,
+}
+
+impl Size {
+    /// Return the number of bits in a size.
+    pub fn bits(self) -> u8 {
+        match self {
+            Size::U16 => 16,
+            Size::U32 => 32,
+            Size::U64 => 64,
+        }
+    }
+
+    /// Return the number of bytes in a size.
+    ///
+    /// For these purposes, there are 8 bits in a byte.
+    pub fn bytes(self) -> u8 {
+        match self {
+            Size::U16 => 2,
+            Size::U32 => 4,
+            Size::U64 => 8,
+        }
+    }
+}
+
+/// The C data model used on a target.
+///
+/// See also https://en.cppreference.com/w/c/language/arithmetic_types
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum CDataModel {
+    /// The data model used most commonly on Win16
+    LP32,
+    /// The data model used most commonly on Win32 and 32-bit Unix systems
+    ILP32,
+    /// The data model used most commonly on Win64
+    LLP64,
+    /// The data model used most commonly on 64-bit Unix systems
+    LP64,
+    /// A rare data model used on early 64-bit Unix systems
+    ILP64,
+}
+
+impl CDataModel {
+    /// The width of a pointer (in the default address space).
+    pub fn pointer_width(&self) -> Size {
+        match self {
+            CDataModel::LP32 | CDataModel::ILP32 => Size::U32,
+            CDataModel::LLP64 | CDataModel::LP64 | CDataModel::ILP64 => Size::U64,
+        }
+    }
+    /// The size of a C `short`. This is required to be at least 16 bits.
+    pub fn short_size(&self) -> Size {
+        match self {
+            CDataModel::LP32 | CDataModel::ILP32 | CDataModel::LLP64 | CDataModel::LP64 | CDataModel::ILP64 => Size::U16,
+        }
+    }
+    /// The size of a C `int`. This is required to be at least 16 bits.
+    pub fn int_size(&self) -> Size {
+        match self {
+            CDataModel::LP32 => Size::U16,
+            CDataModel::ILP32 | CDataModel::LLP64 | CDataModel::LP64 | CDataModel::ILP64 => Size::U32,
+        }
+    }
+    /// The size of a C `long`. This is required to be at least 32 bits.
+    pub fn long_size(&self) -> Size {
+        match self {
+            CDataModel::LP32 | CDataModel::ILP32 | CDataModel::LLP64 | CDataModel::ILP64 => Size::U32,
+            CDataModel::LP64 => Size::U64,
+        }
+    }
+    /// The size of a C `long long`. This is required (in C99+) to be at least 64 bits.
+    pub fn long_long_size(&self) -> Size {
+        match self {
+            CDataModel::LP32 | CDataModel::ILP32 | CDataModel::LLP64 | CDataModel::ILP64 | CDataModel::LP64 => Size::U64,
+        }
+    }
+    /// The size of a C `float`.
+    pub fn float_size(&self) -> Size {
+        // TODO: this is probably wrong on at least one architecture
+        Size::U32
+    }
+    /// The size of a C `double`.
+    pub fn double_size(&self) -> Size {
+        // TODO: this is probably wrong on at least one architecture
+        Size::U64
+    }
+}

--- a/src/data_model.rs
+++ b/src/data_model.rs
@@ -9,7 +9,7 @@ pub struct Size {
 }
 
 impl Size {
-    /// Return the number of bits in a size.
+    /// Return the number of bits this `Size` represents.
     pub fn bits(self) -> u8 {
         self.bits
     }

--- a/src/data_model.rs
+++ b/src/data_model.rs
@@ -38,15 +38,23 @@ impl Size {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum CDataModel {
-    /// The data model used most commonly on Win16
+    /// The data model used most commonly on Win16. `int` and `long` are 32 bits.
     LP32,
-    /// The data model used most commonly on Win32 and 32-bit Unix systems
+    /// The data model used most commonly on Win32 and 32-bit Unix systems.
+    ///
+    /// `int`, `long`, and `pointer` are all 32 bits.
     ILP32,
     /// The data model used most commonly on Win64
+    ///
+    /// `long long`, and `pointer` are 64 bits.
     LLP64,
     /// The data model used most commonly on 64-bit Unix systems
+    ///
+    /// `long`, and `pointer` are 64 bits.
     LP64,
     /// A rare data model used on early 64-bit Unix systems
+    ///
+    /// `int`, `long`, and `pointer` are all 64 bits.
     ILP64,
 }
 

--- a/src/data_model.rs
+++ b/src/data_model.rs
@@ -1,32 +1,33 @@
 /// The size of a type.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub struct Size {
-    /// The size in bits of this type.
-    bits: u8,
-    /// The number of bits in a byte.
-    char_bit: u8,
+#[allow(missing_docs)]
+pub enum Size {
+    U8,
+    U16,
+    U32,
+    U64,
 }
 
 impl Size {
     /// Return the number of bits this `Size` represents.
     pub fn bits(self) -> u8 {
-        self.bits
+        match self {
+            Size::U8 => 8,
+            Size::U16 => 16,
+            Size::U32 => 32,
+            Size::U64 => 64,
+        }
     }
 
     /// Return the number of bytes in a size.
     ///
-    /// Depending on the target, a byte may not necessarily be 8 bits.
+    /// A byte is assumed to be 8 bits.
     pub fn bytes(self) -> u8 {
-        let bytes = self.bits / self.char_bit;
-        // make sure that self.bits is a multiple of char_bit
-        assert_eq!(bytes * self.char_bit, self.bits);
-        bytes
-    }
-    /// Create a new `Size`, assuming that `char_bit` is 8.
-    fn with_bits(bits: u8) -> Self {
-        Self {
-            bits,
-            char_bit: 8,
+        match self {
+            Size::U8 => 1,
+            Size::U16 => 2,
+            Size::U32 => 4,
+            Size::U64 => 8,
         }
     }
 }
@@ -61,44 +62,44 @@ impl CDataModel {
     /// The width of a pointer (in the default address space).
     pub fn pointer_width(&self) -> Size {
         match self {
-            CDataModel::LP32 | CDataModel::ILP32 => Size::with_bits(32),
-            CDataModel::LLP64 | CDataModel::LP64 | CDataModel::ILP64 => Size::with_bits(64),
+            CDataModel::LP32 | CDataModel::ILP32 => Size::U32,
+            CDataModel::LLP64 | CDataModel::LP64 | CDataModel::ILP64 => Size::U64,
         }
     }
     /// The size of a C `short`. This is required to be at least 16 bits.
     pub fn short_size(&self) -> Size {
         match self {
-            CDataModel::LP32 | CDataModel::ILP32 | CDataModel::LLP64 | CDataModel::LP64 | CDataModel::ILP64 => Size::with_bits(16),
+            CDataModel::LP32 | CDataModel::ILP32 | CDataModel::LLP64 | CDataModel::LP64 | CDataModel::ILP64 => Size::U16,
         }
     }
     /// The size of a C `int`. This is required to be at least 16 bits.
     pub fn int_size(&self) -> Size {
         match self {
-            CDataModel::LP32 => Size::with_bits(16),
-            CDataModel::ILP32 | CDataModel::LLP64 | CDataModel::LP64 | CDataModel::ILP64 => Size::with_bits(32),
+            CDataModel::LP32 => Size::U16,
+            CDataModel::ILP32 | CDataModel::LLP64 | CDataModel::LP64 | CDataModel::ILP64 => Size::U32,
         }
     }
     /// The size of a C `long`. This is required to be at least 32 bits.
     pub fn long_size(&self) -> Size {
         match self {
-            CDataModel::LP32 | CDataModel::ILP32 | CDataModel::LLP64 | CDataModel::ILP64 => Size::with_bits(32),
-            CDataModel::LP64 => Size::with_bits(64),
+            CDataModel::LP32 | CDataModel::ILP32 | CDataModel::LLP64 | CDataModel::ILP64 => Size::U32,
+            CDataModel::LP64 => Size::U64,
         }
     }
     /// The size of a C `long long`. This is required (in C99+) to be at least 64 bits.
     pub fn long_long_size(&self) -> Size {
         match self {
-            CDataModel::LP32 | CDataModel::ILP32 | CDataModel::LLP64 | CDataModel::ILP64 | CDataModel::LP64 => Size::with_bits(64),
+            CDataModel::LP32 | CDataModel::ILP32 | CDataModel::LLP64 | CDataModel::ILP64 | CDataModel::LP64 => Size::U64,
         }
     }
     /// The size of a C `float`.
     pub fn float_size(&self) -> Size {
         // TODO: this is probably wrong on at least one architecture
-        Size::with_bits(32)
+        Size::U32
     }
     /// The size of a C `double`.
     pub fn double_size(&self) -> Size {
         // TODO: this is probably wrong on at least one architecture
-        Size::with_bits(64)
+        Size::U64
     }
 }

--- a/src/data_model.rs
+++ b/src/data_model.rs
@@ -1,30 +1,33 @@
-/// The size in bits of a type.
+/// The size of a type.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[allow(missing_docs)]
-pub enum Size {
-    U16,
-    U32,
-    U64,
+pub struct Size {
+    /// The size in bits of this type.
+    bits: u8,
+    /// The number of bits in a byte.
+    char_bit: u8,
 }
 
 impl Size {
     /// Return the number of bits in a size.
     pub fn bits(self) -> u8 {
-        match self {
-            Size::U16 => 16,
-            Size::U32 => 32,
-            Size::U64 => 64,
-        }
+        self.bits
     }
 
     /// Return the number of bytes in a size.
     ///
-    /// For these purposes, there are 8 bits in a byte.
+    /// Depending on the target, a byte may not necessarily be 8 bits.
     pub fn bytes(self) -> u8 {
-        match self {
-            Size::U16 => 2,
-            Size::U32 => 4,
-            Size::U64 => 8,
+        let bytes = self.bits / self.char_bit;
+        // make sure that self.bits is a multiple of char_bit
+        assert_eq!(bytes * self.char_bit, self.bits);
+        bytes
+    }
+    /// Create a new `Size`, assuming that `char_bit` is 8.
+    fn with_bits(bits: u8) -> Self {
+        Self {
+            bits,
+            char_bit: 8,
         }
     }
 }
@@ -51,44 +54,44 @@ impl CDataModel {
     /// The width of a pointer (in the default address space).
     pub fn pointer_width(&self) -> Size {
         match self {
-            CDataModel::LP32 | CDataModel::ILP32 => Size::U32,
-            CDataModel::LLP64 | CDataModel::LP64 | CDataModel::ILP64 => Size::U64,
+            CDataModel::LP32 | CDataModel::ILP32 => Size::with_bits(32),
+            CDataModel::LLP64 | CDataModel::LP64 | CDataModel::ILP64 => Size::with_bits(64),
         }
     }
     /// The size of a C `short`. This is required to be at least 16 bits.
     pub fn short_size(&self) -> Size {
         match self {
-            CDataModel::LP32 | CDataModel::ILP32 | CDataModel::LLP64 | CDataModel::LP64 | CDataModel::ILP64 => Size::U16,
+            CDataModel::LP32 | CDataModel::ILP32 | CDataModel::LLP64 | CDataModel::LP64 | CDataModel::ILP64 => Size::with_bits(16),
         }
     }
     /// The size of a C `int`. This is required to be at least 16 bits.
     pub fn int_size(&self) -> Size {
         match self {
-            CDataModel::LP32 => Size::U16,
-            CDataModel::ILP32 | CDataModel::LLP64 | CDataModel::LP64 | CDataModel::ILP64 => Size::U32,
+            CDataModel::LP32 => Size::with_bits(16),
+            CDataModel::ILP32 | CDataModel::LLP64 | CDataModel::LP64 | CDataModel::ILP64 => Size::with_bits(32),
         }
     }
     /// The size of a C `long`. This is required to be at least 32 bits.
     pub fn long_size(&self) -> Size {
         match self {
-            CDataModel::LP32 | CDataModel::ILP32 | CDataModel::LLP64 | CDataModel::ILP64 => Size::U32,
-            CDataModel::LP64 => Size::U64,
+            CDataModel::LP32 | CDataModel::ILP32 | CDataModel::LLP64 | CDataModel::ILP64 => Size::with_bits(32),
+            CDataModel::LP64 => Size::with_bits(64),
         }
     }
     /// The size of a C `long long`. This is required (in C99+) to be at least 64 bits.
     pub fn long_long_size(&self) -> Size {
         match self {
-            CDataModel::LP32 | CDataModel::ILP32 | CDataModel::LLP64 | CDataModel::ILP64 | CDataModel::LP64 => Size::U64,
+            CDataModel::LP32 | CDataModel::ILP32 | CDataModel::LLP64 | CDataModel::ILP64 | CDataModel::LP64 => Size::with_bits(64),
         }
     }
     /// The size of a C `float`.
     pub fn float_size(&self) -> Size {
         // TODO: this is probably wrong on at least one architecture
-        Size::U32
+        Size::with_bits(32)
     }
     /// The size of a C `double`.
     pub fn double_size(&self) -> Size {
         // TODO: this is probably wrong on at least one architecture
-        Size::U64
+        Size::with_bits(64)
     }
 }

--- a/src/data_model.rs
+++ b/src/data_model.rs
@@ -1,6 +1,5 @@
 /// The size of a type.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-#[allow(missing_docs)]
 pub struct Size {
     /// The size in bits of this type.
     bits: u8,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,18 +19,18 @@
 
 extern crate alloc;
 
+mod data_model;
 mod host;
 mod parse_error;
 mod targets;
 #[macro_use]
 mod triple;
 
+pub use self::data_model::{CDataModel, Size};
 pub use self::host::HOST;
 pub use self::parse_error::ParseError;
 pub use self::targets::{
     Aarch64Architecture, Architecture, ArmArchitecture, BinaryFormat, CustomVendor, Environment,
     OperatingSystem, Vendor,
 };
-pub use self::triple::{CallingConvention, CDataModel, Endianness, Size, Triple};
-/// The size of a pointer
-pub type PointerWidth = Size;
+pub use self::triple::{CallingConvention, Endianness, PointerWidth, Triple};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,6 @@ pub use self::targets::{
     Aarch64Architecture, Architecture, ArmArchitecture, BinaryFormat, CustomVendor, Environment,
     OperatingSystem, Vendor,
 };
-pub use self::triple::{CallingConvention, Endianness, Size, Triple};
+pub use self::triple::{CallingConvention, CDataModel, Endianness, Size, Triple};
 /// The size of a pointer
 pub type PointerWidth = Size;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,4 +31,6 @@ pub use self::targets::{
     Aarch64Architecture, Architecture, ArmArchitecture, BinaryFormat, CustomVendor, Environment,
     OperatingSystem, Vendor,
 };
-pub use self::triple::{CallingConvention, Endianness, PointerWidth, Triple};
+pub use self::triple::{CallingConvention, Endianness, Size, Triple};
+/// The size of a pointer
+pub type PointerWidth = Size;

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -1,6 +1,6 @@
 // This file defines all the identifier enums and target-aware logic.
 
-use crate::triple::{Endianness, Size, Triple};
+use crate::triple::{Endianness, PointerWidth, Triple};
 use alloc::boxed::Box;
 use alloc::string::String;
 use core::fmt;
@@ -173,7 +173,7 @@ impl ArmArchitecture {
     // }
 
     /// Return the pointer bit width of this target's architecture.
-    pub fn pointer_width(self) -> Size {
+    pub fn pointer_width(self) -> PointerWidth {
         match self {
             ArmArchitecture::Arm
             | ArmArchitecture::Armeb
@@ -213,7 +213,7 @@ impl ArmArchitecture {
             | ArmArchitecture::Thumbv7m
             | ArmArchitecture::Thumbv7neon
             | ArmArchitecture::Thumbv8mBase
-            | ArmArchitecture::Thumbv8mMain => Size::U32,
+            | ArmArchitecture::Thumbv8mMain => PointerWidth::U32,
         }
     }
 
@@ -276,9 +276,9 @@ impl Aarch64Architecture {
     // }
 
     /// Return the pointer bit width of this target's architecture.
-    pub fn pointer_width(self) -> Size {
+    pub fn pointer_width(self) -> PointerWidth {
         match self {
-            Aarch64Architecture::Aarch64 | Aarch64Architecture::Aarch64be => Size::U64,
+            Aarch64Architecture::Aarch64 | Aarch64Architecture::Aarch64be => PointerWidth::U64,
         }
     }
 
@@ -495,10 +495,10 @@ impl Architecture {
     }
 
     /// Return the pointer bit width of this target's architecture.
-    pub fn pointer_width(self) -> Result<Size, ()> {
+    pub fn pointer_width(self) -> Result<PointerWidth, ()> {
         match self {
             Architecture::Unknown => Err(()),
-            Architecture::Msp430 => Ok(Size::U16),
+            Architecture::Msp430 => Ok(PointerWidth::U16),
             Architecture::Arm(arm) => Ok(arm.pointer_width()),
             Architecture::Aarch64(aarch) => Ok(aarch.pointer_width()),
             Architecture::Asmjs
@@ -511,7 +511,7 @@ impl Architecture {
             | Architecture::Sparc
             | Architecture::Wasm32
             | Architecture::Mips
-            | Architecture::Powerpc => Ok(Size::U32),
+            | Architecture::Powerpc => Ok(PointerWidth::U32),
             Architecture::AmdGcn
             | Architecture::Mips64el
             | Architecture::Mipsisa64r6
@@ -525,7 +525,7 @@ impl Architecture {
             | Architecture::S390x
             | Architecture::Sparc64
             | Architecture::Sparcv9
-            | Architecture::Wasm64 => Ok(Size::U64),
+            | Architecture::Wasm64 => Ok(PointerWidth::U64),
         }
     }
 }

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -1,6 +1,6 @@
 // This file defines all the identifier enums and target-aware logic.
 
-use crate::triple::{Endianness, PointerWidth, Triple};
+use crate::triple::{Endianness, Size, Triple};
 use alloc::boxed::Box;
 use alloc::string::String;
 use core::fmt;
@@ -173,7 +173,7 @@ impl ArmArchitecture {
     // }
 
     /// Return the pointer bit width of this target's architecture.
-    pub fn pointer_width(self) -> PointerWidth {
+    pub fn pointer_width(self) -> Size {
         match self {
             ArmArchitecture::Arm
             | ArmArchitecture::Armeb
@@ -213,7 +213,7 @@ impl ArmArchitecture {
             | ArmArchitecture::Thumbv7m
             | ArmArchitecture::Thumbv7neon
             | ArmArchitecture::Thumbv8mBase
-            | ArmArchitecture::Thumbv8mMain => PointerWidth::U32,
+            | ArmArchitecture::Thumbv8mMain => Size::U32,
         }
     }
 
@@ -276,9 +276,9 @@ impl Aarch64Architecture {
     // }
 
     /// Return the pointer bit width of this target's architecture.
-    pub fn pointer_width(self) -> PointerWidth {
+    pub fn pointer_width(self) -> Size {
         match self {
-            Aarch64Architecture::Aarch64 | Aarch64Architecture::Aarch64be => PointerWidth::U64,
+            Aarch64Architecture::Aarch64 | Aarch64Architecture::Aarch64be => Size::U64,
         }
     }
 
@@ -495,10 +495,10 @@ impl Architecture {
     }
 
     /// Return the pointer bit width of this target's architecture.
-    pub fn pointer_width(self) -> Result<PointerWidth, ()> {
+    pub fn pointer_width(self) -> Result<Size, ()> {
         match self {
             Architecture::Unknown => Err(()),
-            Architecture::Msp430 => Ok(PointerWidth::U16),
+            Architecture::Msp430 => Ok(Size::U16),
             Architecture::Arm(arm) => Ok(arm.pointer_width()),
             Architecture::Aarch64(aarch) => Ok(aarch.pointer_width()),
             Architecture::Asmjs
@@ -511,7 +511,7 @@ impl Architecture {
             | Architecture::Sparc
             | Architecture::Wasm32
             | Architecture::Mips
-            | Architecture::Powerpc => Ok(PointerWidth::U32),
+            | Architecture::Powerpc => Ok(Size::U32),
             Architecture::AmdGcn
             | Architecture::Mips64el
             | Architecture::Mipsisa64r6
@@ -525,7 +525,7 @@ impl Architecture {
             | Architecture::S390x
             | Architecture::Sparc64
             | Architecture::Sparcv9
-            | Architecture::Wasm64 => Ok(PointerWidth::U64),
+            | Architecture::Wasm64 => Ok(Size::U64),
         }
     }
 }

--- a/src/triple.rs
+++ b/src/triple.rs
@@ -17,6 +17,7 @@ pub enum Endianness {
     Big,
 }
 
+/// The size in bits of a type.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[allow(missing_docs)]
 pub enum Size {

--- a/src/triple.rs
+++ b/src/triple.rs
@@ -130,29 +130,32 @@ impl Triple {
 
     /// The C data model for a given target. If the model is not known, returns `Err(())`.
     pub fn data_model(&self) -> Result<CDataModel, ()> {
-        let pointer_width = self.pointer_width()?;
-        if pointer_width == PointerWidth::U64 {
-            if self.operating_system == OperatingSystem::Windows {
-                Ok(CDataModel::LLP64)
-            } else if self.default_calling_convention() == Ok(CallingConvention::SystemV)
-                || self.architecture == Architecture::Wasm64 {
-                Ok(CDataModel::LP64)
-            } else {
-                Err(())
+        match self.pointer_width()? {
+            PointerWidth::U64 => {
+                if self.operating_system == OperatingSystem::Windows {
+                    Ok(CDataModel::LLP64)
+                } else if self.default_calling_convention() == Ok(CallingConvention::SystemV)
+                    || self.architecture == Architecture::Wasm64 {
+                    Ok(CDataModel::LP64)
+                } else {
+                    Err(())
+                }
             }
-        } else if pointer_width == PointerWidth::U32 {
-            if self.operating_system == OperatingSystem::Windows
-                || self.default_calling_convention() == Ok(CallingConvention::SystemV)
-                || self.architecture == Architecture::Wasm32 {
-                Ok(CDataModel::ILP32)
-            } else {
-                Err(())
+            PointerWidth::U32 => {
+                if self.operating_system == OperatingSystem::Windows
+                    || self.default_calling_convention() == Ok(CallingConvention::SystemV)
+                    || self.architecture == Architecture::Wasm32 {
+                    Ok(CDataModel::ILP32)
+                } else {
+                    Err(())
+                }
             }
-        } else {
-            if self.operating_system == OperatingSystem::Windows {
-                Ok(CDataModel::LP32)
-            } else {
-                Err(())
+            PointerWidth::U16 => {
+                if self.operating_system == OperatingSystem::Windows {
+                    Ok(CDataModel::LP32)
+                } else {
+                    Err(())
+                }
             }
         }
     }

--- a/src/triple.rs
+++ b/src/triple.rs
@@ -150,13 +150,11 @@ impl Triple {
                     Err(())
                 }
             }
-            PointerWidth::U16 => {
-                if self.operating_system == OperatingSystem::Windows {
-                    Ok(CDataModel::LP32)
-                } else {
-                    Err(())
-                }
-            }
+            // TODO: on 16-bit machines there is usually a distinction
+            // between near-pointers and far-pointers.
+            // Additionally, code pointers sometimes have a different size than data pointers.
+            // We don't handle this case.
+            PointerWidth::U16 => Err(()),
         }
     }
 }

--- a/src/triple.rs
+++ b/src/triple.rs
@@ -17,33 +17,32 @@ pub enum Endianness {
     Big,
 }
 
-/// The width of a pointer (in the default address space).
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[allow(missing_docs)]
-pub enum PointerWidth {
+pub enum Size {
     U16,
     U32,
     U64,
 }
 
-impl PointerWidth {
-    /// Return the number of bits in a pointer.
+impl Size {
+    /// Return the number of bits in a size.
     pub fn bits(self) -> u8 {
         match self {
-            PointerWidth::U16 => 16,
-            PointerWidth::U32 => 32,
-            PointerWidth::U64 => 64,
+            Size::U16 => 16,
+            Size::U32 => 32,
+            Size::U64 => 64,
         }
     }
 
-    /// Return the number of bytes in a pointer.
+    /// Return the number of bytes in a size.
     ///
     /// For these purposes, there are 8 bits in a byte.
     pub fn bytes(self) -> u8 {
         match self {
-            PointerWidth::U16 => 2,
-            PointerWidth::U32 => 4,
-            PointerWidth::U64 => 8,
+            Size::U16 => 2,
+            Size::U32 => 4,
+            Size::U64 => 8,
         }
     }
 }
@@ -93,7 +92,7 @@ impl Triple {
     }
 
     /// Return the pointer width of this target's architecture.
-    pub fn pointer_width(&self) -> Result<PointerWidth, ()> {
+    pub fn pointer_width(&self) -> Result<Size, ()> {
         self.architecture.pointer_width()
     }
 

--- a/src/triple.rs
+++ b/src/triple.rs
@@ -189,6 +189,32 @@ impl Triple {
             _ => return Err(()),
         })
     }
+
+    /// The C data model for a given target.
+    pub fn data_model(&self) -> Result<CDataModel, ()> {
+        let pointer_width = self.pointer_width()?;
+        if pointer_width == Size::U64 {
+            if self.operating_system == OperatingSystem::Windows {
+                Ok(CDataModel::LLP64)
+            } else if self.default_calling_convention() == Ok(CallingConvention::SystemV) {
+                Ok(CDataModel::LP64)
+            } else {
+                Err(())
+            }
+        } else if pointer_width == Size::U32 {
+            if self.operating_system == OperatingSystem::Windows || self.default_calling_convention() == Ok(CallingConvention::SystemV) {
+                Ok(CDataModel::ILP32)
+            } else {
+                Err(())
+            }
+        } else {
+            if self.operating_system == OperatingSystem::Windows {
+                Ok(CDataModel::LP32)
+            } else {
+                Err(())
+            }
+        }
+    }
 }
 
 impl Default for Triple {

--- a/src/triple.rs
+++ b/src/triple.rs
@@ -128,7 +128,7 @@ impl Triple {
         })
     }
 
-    /// The C data model for a given target.
+    /// The C data model for a given target. If the model is not known, returns `Err(())`.
     pub fn data_model(&self) -> Result<CDataModel, ()> {
         let pointer_width = self.pointer_width()?;
         if pointer_width == PointerWidth::U64 {

--- a/src/triple.rs
+++ b/src/triple.rs
@@ -51,7 +51,6 @@ impl PointerWidth {
 /// The calling convention, which specifies things like which registers are
 /// used for passing arguments, which registers are callee-saved, and so on.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-#[allow(missing_docs)]
 pub enum CallingConvention {
     /// "System V", which is used on most Unix-like platfoms. Note that the
     /// specific conventions vary between hardware architectures; for example,

--- a/src/triple.rs
+++ b/src/triple.rs
@@ -134,13 +134,16 @@ impl Triple {
         if pointer_width == PointerWidth::U64 {
             if self.operating_system == OperatingSystem::Windows {
                 Ok(CDataModel::LLP64)
-            } else if self.default_calling_convention() == Ok(CallingConvention::SystemV) {
+            } else if self.default_calling_convention() == Ok(CallingConvention::SystemV)
+                || self.architecture == Architecture::Wasm64 {
                 Ok(CDataModel::LP64)
             } else {
                 Err(())
             }
         } else if pointer_width == PointerWidth::U32 {
-            if self.operating_system == OperatingSystem::Windows || self.default_calling_convention() == Ok(CallingConvention::SystemV) {
+            if self.operating_system == OperatingSystem::Windows
+                || self.default_calling_convention() == Ok(CallingConvention::SystemV)
+                || self.architecture == Architecture::Wasm32 {
                 Ok(CDataModel::ILP32)
             } else {
                 Err(())

--- a/src/triple.rs
+++ b/src/triple.rs
@@ -68,6 +68,70 @@ pub enum CallingConvention {
     WindowsFastcall,
 }
 
+/// The C data model used on a target.
+///
+/// See also https://en.cppreference.com/w/c/language/arithmetic_types
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum CDataModel {
+    /// The data model used most commonly on Win16
+    LP32,
+    /// The data model used most commonly on Win32 and 32-bit Unix systems
+    ILP32,
+    /// The data model used most commonly on Win64
+    LLP64,
+    /// The data model used most commonly on 64-bit Unix systems
+    LP64,
+    /// A rare data model used on early 64-bit Unix systems
+    ILP64,
+}
+
+impl CDataModel {
+    /// The width of a pointer (in the default address space).
+    pub fn pointer_width(&self) -> Size {
+        match self {
+            CDataModel::LP32 | CDataModel::ILP32 => Size::U32,
+            CDataModel::LLP64 | CDataModel::LP64 | CDataModel::ILP64 => Size::U64,
+        }
+    }
+    /// The size of a C `short`. This is required to be at least 16 bits.
+    pub fn short_size(&self) -> Size {
+        match self {
+            CDataModel::LP32 | CDataModel::ILP32 | CDataModel::LLP64 | CDataModel::LP64 | CDataModel::ILP64 => Size::U16,
+        }
+    }
+    /// The size of a C `int`. This is required to be at least 16 bits.
+    pub fn int_size(&self) -> Size {
+        match self {
+            CDataModel::LP32 => Size::U16,
+            CDataModel::ILP32 | CDataModel::LLP64 | CDataModel::LP64 | CDataModel::ILP64 => Size::U32,
+        }
+    }
+    /// The size of a C `long`. This is required to be at least 32 bits.
+    pub fn long_size(&self) -> Size {
+        match self {
+            CDataModel::LP32 | CDataModel::ILP32 | CDataModel::LLP64 | CDataModel::ILP64 => Size::U32,
+            CDataModel::LP64 => Size::U64,
+        }
+    }
+    /// The size of a C `long long`. This is required (in C99+) to be at least 64 bits.
+    pub fn long_long_size(&self) -> Size {
+        match self {
+            CDataModel::LP32 | CDataModel::ILP32 | CDataModel::LLP64 | CDataModel::ILP64 | CDataModel::LP64 => Size::U64,
+        }
+    }
+    /// The size of a C `float`.
+    pub fn float_size(&self) -> Size {
+        // TODO: this is probably wrong on at least one architecture
+        Size::U32
+    }
+    /// The size of a C `double`.
+    pub fn double_size(&self) -> Size {
+        // TODO: this is probably wrong on at least one architecture
+        Size::U64
+    }
+}
+
 /// A target "triple". Historically such things had three fields, though they've
 /// added additional fields over time.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]


### PR DESCRIPTION
Closes #47 

- ~~Rename `PointerWidth` to `Size` and use it for other types as well~~
- Add new `Size` enum
- Add `CDataModel` and `data_model()` function to `impl Triple`

My main question is how to tell what data model belongs to which target. I have some very broad heuristics but there's too many possible triples to match them all exhaustively (over 200000!)