### PR TITLE
Mark hermit as unix-like

### DIFF
--- a/src/triple.rs
+++ b/src/triple.rs
@@ -108,6 +108,7 @@ impl Triple {
             | OperatingSystem::Freebsd
             | OperatingSystem::Fuchsia
             | OperatingSystem::Haiku
+            | OperatingSystem::Hermit
             | OperatingSystem::Ios
             | OperatingSystem::L4re
             | OperatingSystem::Linux


### PR DESCRIPTION
See https://github.com/rust-lang/rust/blob/9ebf47851a357faa4cd97f4b1dc7835f6376e639/src/librustc_target/spec/hermit_base.rs, as well as https://hermitcore.org/getting-started/#as-multi-kernel-within-a-virtual-machine which seems to indicate ABI-compatibility with Linux (?)