### PR TITLE
Add a utility to implement Default using Triple::unknown() too.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,3 +44,13 @@ impl Default for DefaultToHost {
         Self(Triple::host())
     }
 }
+
+/// A simple wrapper around `Triple` that provides an implementation of
+/// `Default` which defaults to `Triple::unknown()`.
+pub struct DefaultToUnknown(pub Triple);
+
+impl Default for DefaultToUnknown {
+    fn default() -> Self {
+        Self(Triple::unknown())
+    }
+}


### PR DESCRIPTION
This isn't much code, and is convenient for users that were previously using the `Default` implementation on `Triple`.