### PR TITLE
Add backwards compatibility with 1.34

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: rust
 rust:
+    - "1.34.0"
     - stable
     - beta
     - nightly
@@ -7,6 +8,7 @@ matrix:
     allow_failures:
         - rust: beta
         - rust: nightly
+
 dist: trusty
 sudo: false
 before_script:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,9 @@ repository = "https://github.com/CraneStation/target-lexicon"
 edition = "2018"
 
 [features]
-default = []
+default = ["rust_1_40"]
+# When enabled, use features that are only available with 1.40 or later.
+rust_1_40 = []
 std = []
 
 [badges]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,7 @@ repository = "https://github.com/CraneStation/target-lexicon"
 edition = "2018"
 
 [features]
-default = ["rust_1_40"]
-# When enabled, use features that are only available with 1.40 or later.
-rust_1_40 = []
+default = []
 std = []
 
 [badges]

--- a/build.rs
+++ b/build.rs
@@ -9,6 +9,9 @@ use std::io::{self, Write};
 use std::path::PathBuf;
 use std::str::FromStr;
 
+#[cfg(feature = "std")]
+extern crate std as alloc;
+#[cfg(not(feature = "std"))]
 extern crate alloc;
 
 // Include triple.rs and targets.rs so we can parse the TARGET environment variable.

--- a/build.rs
+++ b/build.rs
@@ -107,7 +107,7 @@ fn write_host_rs(mut out: File, triple: Triple) -> io::Result<()> {
     writeln!(out, "impl Architecture {{")?;
     writeln!(out, "    /// Return the architecture for the current host.")?;
     writeln!(out, "    pub const fn host() -> Self {{")?;
-    writeln!(out, "        Self::{:?}", triple.architecture)?;
+    writeln!(out, "        Architecture::{:?}", triple.architecture)?;
     writeln!(out, "    }}")?;
     writeln!(out, "}}")?;
     writeln!(out)?;
@@ -115,7 +115,7 @@ fn write_host_rs(mut out: File, triple: Triple) -> io::Result<()> {
     writeln!(out, "impl Vendor {{")?;
     writeln!(out, "    /// Return the vendor for the current host.")?;
     writeln!(out, "    pub const fn host() -> Self {{")?;
-    writeln!(out, "        Self::{}", vendor_display(&triple.vendor))?;
+    writeln!(out, "        Vendor::{}", vendor_display(&triple.vendor))?;
     writeln!(out, "    }}")?;
     writeln!(out, "}}")?;
     writeln!(out)?;
@@ -126,7 +126,7 @@ fn write_host_rs(mut out: File, triple: Triple) -> io::Result<()> {
         "    /// Return the operating system for the current host."
     )?;
     writeln!(out, "    pub const fn host() -> Self {{")?;
-    writeln!(out, "        Self::{:?}", triple.operating_system)?;
+    writeln!(out, "        OperatingSystem::{:?}", triple.operating_system)?;
     writeln!(out, "    }}")?;
     writeln!(out, "}}")?;
     writeln!(out)?;
@@ -134,7 +134,7 @@ fn write_host_rs(mut out: File, triple: Triple) -> io::Result<()> {
     writeln!(out, "impl Environment {{")?;
     writeln!(out, "    /// Return the environment for the current host.")?;
     writeln!(out, "    pub const fn host() -> Self {{")?;
-    writeln!(out, "        Self::{:?}", triple.environment)?;
+    writeln!(out, "        Environment::{:?}", triple.environment)?;
     writeln!(out, "    }}")?;
     writeln!(out, "}}")?;
     writeln!(out)?;
@@ -145,7 +145,7 @@ fn write_host_rs(mut out: File, triple: Triple) -> io::Result<()> {
         "    /// Return the binary format for the current host."
     )?;
     writeln!(out, "    pub const fn host() -> Self {{")?;
-    writeln!(out, "        Self::{:?}", triple.binary_format)?;
+    writeln!(out, "        BinaryFormat::{:?}", triple.binary_format)?;
     writeln!(out, "    }}")?;
     writeln!(out, "}}")?;
     writeln!(out)?;

--- a/build.rs
+++ b/build.rs
@@ -7,6 +7,7 @@ use std::env;
 use std::fs::File;
 use std::io::{self, Write};
 use std::path::PathBuf;
+use std::process::Command;
 use std::str::FromStr;
 
 #[cfg(feature = "std")]
@@ -50,6 +51,23 @@ fn main() {
         Triple::from_str(&target).unwrap_or_else(|_| panic!("Invalid target name: '{}'", target));
     let out = File::create(out_dir.join("host.rs")).expect("error creating host.rs");
     write_host_rs(out, triple).expect("error writing host.rs");
+    if using_less_1_40().is_none() {
+        println!("cargo:rustc-cfg=feature=\"rust_1_40\"");
+    }
+}
+
+fn using_less_1_40() -> Option<()> {
+    let stdout = match Command::new("rustc").arg("--version").output() {
+        Ok(output) if output.status.success() => output.stdout,
+        // Assume we're up-to-date, rustc wasn't found in PATH
+        _ => return None,
+    };
+    let version: i32 = std::str::from_utf8(&stdout).ok()?.split(' ').nth(1)?.parse().ok()?;
+    if version < 40 {
+        Some(())
+    } else {
+        None
+    }
 }
 
 fn write_host_rs(mut out: File, triple: Triple) -> io::Result<()> {

--- a/src/data_model.rs
+++ b/src/data_model.rs
@@ -11,11 +11,13 @@ pub enum Size {
 impl Size {
     /// Return the number of bits this `Size` represents.
     pub fn bits(self) -> u8 {
+        use Size::*;
+
         match self {
-            Self::U8 => 8,
-            Self::U16 => 16,
-            Self::U32 => 32,
-            Self::U64 => 64,
+            U8 => 8,
+            U16 => 16,
+            U32 => 32,
+            U64 => 64,
         }
     }
 
@@ -23,11 +25,13 @@ impl Size {
     ///
     /// A byte is assumed to be 8 bits.
     pub fn bytes(self) -> u8 {
+        use Size::*;
+
         match self {
-            Self::U8 => 1,
-            Self::U16 => 2,
-            Self::U32 => 4,
-            Self::U64 => 8,
+            U8 => 1,
+            U16 => 2,
+            U32 => 4,
+            U64 => 8,
         }
     }
 }
@@ -61,35 +65,45 @@ pub enum CDataModel {
 impl CDataModel {
     /// The width of a pointer (in the default address space).
     pub fn pointer_width(self) -> Size {
+        use CDataModel::*;
+
         match self {
-            Self::LP32 | Self::ILP32 => Size::U32,
-            Self::LLP64 | Self::LP64 | Self::ILP64 => Size::U64,
+            LP32 | ILP32 => Size::U32,
+            LLP64 | LP64 | ILP64 => Size::U64,
         }
     }
     /// The size of a C `short`. This is required to be at least 16 bits.
     pub fn short_size(self) -> Size {
+        use CDataModel::*;
+
         match self {
-            Self::LP32 | Self::ILP32 | Self::LLP64 | Self::LP64 | Self::ILP64 => Size::U16,
+            LP32 | ILP32 | LLP64 | LP64 | ILP64 => Size::U16,
         }
     }
     /// The size of a C `int`. This is required to be at least 16 bits.
     pub fn int_size(self) -> Size {
+        use CDataModel::*;
+
         match self {
-            Self::LP32 => Size::U16,
-            Self::ILP32 | Self::LLP64 | Self::LP64 | Self::ILP64 => Size::U32,
+            LP32 => Size::U16,
+            ILP32 | LLP64 | LP64 | ILP64 => Size::U32,
         }
     }
     /// The size of a C `long`. This is required to be at least 32 bits.
     pub fn long_size(self) -> Size {
+        use CDataModel::*;
+
         match self {
-            Self::LP32 | Self::ILP32 | Self::LLP64 | Self::ILP64 => Size::U32,
-            Self::LP64 => Size::U64,
+            LP32 | ILP32 | LLP64 | ILP64 => Size::U32,
+            LP64 => Size::U64,
         }
     }
     /// The size of a C `long long`. This is required (in C99+) to be at least 64 bits.
     pub fn long_long_size(self) -> Size {
+        use CDataModel::*;
+
         match self {
-            Self::LP32 | Self::ILP32 | Self::LLP64 | Self::ILP64 | Self::LP64 => Size::U64,
+            LP32 | ILP32 | LLP64 | ILP64 | LP64 => Size::U64,
         }
     }
     /// The size of a C `float`.

--- a/src/data_model.rs
+++ b/src/data_model.rs
@@ -40,7 +40,7 @@ impl Size {
 ///
 /// See also https://en.cppreference.com/w/c/language/arithmetic_types
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-#[non_exhaustive]
+#[cfg_attr(feature = "rust_1_40", non_exhaustive)]
 pub enum CDataModel {
     /// The data model used most commonly on Win16. `long` and `pointer` are 32 bits.
     LP32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,11 @@
         clippy::use_self,
     )
 )]
-#![cfg_attr(not(feature = "std"), no_std)]
 
+#![cfg_attr(not(feature = "std"), no_std)]
+#[cfg(feature = "std")]
+extern crate std as alloc;
+#[cfg(not(feature = "std"))]
 extern crate alloc;
 
 mod data_model;

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -9,7 +9,7 @@ use core::str::FromStr;
 
 /// The "architecture" field, which in some cases also specifies a specific
 /// subarchitecture.
-#[non_exhaustive]
+#[cfg_attr(feature = "rust_1_40", non_exhaustive)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[allow(missing_docs)]
 pub enum Architecture {
@@ -38,7 +38,7 @@ pub enum Architecture {
     X86_64,
 }
 
-#[non_exhaustive]
+#[cfg_attr(feature = "rust_1_40", non_exhaustive)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[allow(missing_docs)]
 pub enum ArmArchitecture {
@@ -85,7 +85,7 @@ pub enum ArmArchitecture {
     Thumbv8mMain,
 }
 
-#[non_exhaustive]
+#[cfg_attr(feature = "rust_1_40", non_exhaustive)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[allow(missing_docs)]
 pub enum Aarch64Architecture {
@@ -93,7 +93,7 @@ pub enum Aarch64Architecture {
     Aarch64be,
 }
 
-// #[non_exhaustive]
+// #[cfg_attr(feature = "rust_1_40", non_exhaustive)]
 // #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 // #[allow(missing_docs)]
 // pub enum ArmFpu {
@@ -290,7 +290,7 @@ impl Aarch64Architecture {
 }
 
 /// An enum for all 32-bit RISC-V architectures.
-#[non_exhaustive]
+#[cfg_attr(feature = "rust_1_40", non_exhaustive)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[allow(missing_docs)]
 pub enum Riscv32Architecture {
@@ -301,7 +301,7 @@ pub enum Riscv32Architecture {
 }
 
 /// An enum for all 64-bit RISC-V architectures.
-#[non_exhaustive]
+#[cfg_attr(feature = "rust_1_40", non_exhaustive)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[allow(missing_docs)]
 pub enum Riscv64Architecture {
@@ -311,7 +311,7 @@ pub enum Riscv64Architecture {
 }
 
 /// An enum for all 32-bit x86 architectures.
-#[non_exhaustive]
+#[cfg_attr(feature = "rust_1_40", non_exhaustive)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[allow(missing_docs)]
 pub enum X86_32Architecture {
@@ -321,7 +321,7 @@ pub enum X86_32Architecture {
 }
 
 /// An enum for all 32-bit MIPS architectures (not just "MIPS32").
-#[non_exhaustive]
+#[cfg_attr(feature = "rust_1_40", non_exhaustive)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[allow(missing_docs)]
 pub enum Mips32Architecture {
@@ -332,7 +332,7 @@ pub enum Mips32Architecture {
 }
 
 /// An enum for all 64-bit MIPS architectures (not just "MIPS64").
-#[non_exhaustive]
+#[cfg_attr(feature = "rust_1_40", non_exhaustive)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[allow(missing_docs)]
 pub enum Mips64Architecture {
@@ -377,7 +377,7 @@ impl Hash for CustomVendor {
 
 /// The "vendor" field, which in practice is little more than an arbitrary
 /// modifier.
-#[non_exhaustive]
+#[cfg_attr(feature = "rust_1_40", non_exhaustive)]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[allow(missing_docs)]
 pub enum Vendor {
@@ -405,7 +405,7 @@ pub enum Vendor {
 
 /// The "operating system" field, which sometimes implies an environment, and
 /// sometimes isn't an actual operating system.
-#[non_exhaustive]
+#[cfg_attr(feature = "rust_1_40", non_exhaustive)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[allow(missing_docs)]
 pub enum OperatingSystem {
@@ -442,7 +442,7 @@ pub enum OperatingSystem {
 /// The "environment" field, which specifies an ABI environment on top of the
 /// operating system. In many configurations, this field is omitted, and the
 /// environment is implied by the operating system.
-#[non_exhaustive]
+#[cfg_attr(feature = "rust_1_40", non_exhaustive)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[allow(missing_docs)]
 pub enum Environment {
@@ -473,7 +473,7 @@ pub enum Environment {
 
 /// The "binary format" field, which is usually omitted, and the binary format
 /// is implied by the other fields.
-#[non_exhaustive]
+#[cfg_attr(feature = "rust_1_40", non_exhaustive)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[allow(missing_docs)]
 pub enum BinaryFormat {

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -119,46 +119,48 @@ pub enum Aarch64Architecture {
 impl ArmArchitecture {
     /// Test if this architecture uses the Thumb instruction set.
     pub fn is_thumb(self) -> bool {
+        use ArmArchitecture::*;
+
         match self {
-            Self::Arm
-            | Self::Armeb
-            | Self::Armv4
-            | Self::Armv4t
-            | Self::Armv5t
-            | Self::Armv5te
-            | Self::Armv5tej
-            | Self::Armv6
-            | Self::Armv6j
-            | Self::Armv6k
-            | Self::Armv6z
-            | Self::Armv6kz
-            | Self::Armv6t2
-            | Self::Armv6m
-            | Self::Armv7
-            | Self::Armv7a
-            | Self::Armv7ve
-            | Self::Armv7m
-            | Self::Armv7r
-            | Self::Armv7s
-            | Self::Armv8
-            | Self::Armv8a
-            | Self::Armv8_1a
-            | Self::Armv8_2a
-            | Self::Armv8_3a
-            | Self::Armv8_4a
-            | Self::Armv8_5a
-            | Self::Armv8mBase
-            | Self::Armv8mMain
-            | Self::Armv8r
-            | Self::Armebv7r => false,
-            Self::Thumbeb
-            | Self::Thumbv6m
-            | Self::Thumbv7a
-            | Self::Thumbv7em
-            | Self::Thumbv7m
-            | Self::Thumbv7neon
-            | Self::Thumbv8mBase
-            | Self::Thumbv8mMain => true,
+            Arm
+            | Armeb
+            | Armv4
+            | Armv4t
+            | Armv5t
+            | Armv5te
+            | Armv5tej
+            | Armv6
+            | Armv6j
+            | Armv6k
+            | Armv6z
+            | Armv6kz
+            | Armv6t2
+            | Armv6m
+            | Armv7
+            | Armv7a
+            | Armv7ve
+            | Armv7m
+            | Armv7r
+            | Armv7s
+            | Armv8
+            | Armv8a
+            | Armv8_1a
+            | Armv8_2a
+            | Armv8_3a
+            | Armv8_4a
+            | Armv8_5a
+            | Armv8mBase
+            | Armv8mMain
+            | Armv8r
+            | Armebv7r => false,
+            Thumbeb
+            | Thumbv6m
+            | Thumbv7a
+            | Thumbv7em
+            | Thumbv7m
+            | Thumbv7neon
+            | Thumbv8mBase
+            | Thumbv8mMain => true,
         }
     }
 
@@ -168,89 +170,93 @@ impl ArmArchitecture {
 
     /// Return the pointer bit width of this target's architecture.
     pub fn pointer_width(self) -> PointerWidth {
+        use ArmArchitecture::*;
+
         match self {
-            Self::Arm
-            | Self::Armeb
-            | Self::Armv4
-            | Self::Armv4t
-            | Self::Armv5t
-            | Self::Armv5te
-            | Self::Armv5tej
-            | Self::Armv6
-            | Self::Armv6j
-            | Self::Armv6k
-            | Self::Armv6z
-            | Self::Armv6kz
-            | Self::Armv6t2
-            | Self::Armv6m
-            | Self::Armv7
-            | Self::Armv7a
-            | Self::Armv7ve
-            | Self::Armv7m
-            | Self::Armv7r
-            | Self::Armv7s
-            | Self::Armv8
-            | Self::Armv8a
-            | Self::Armv8_1a
-            | Self::Armv8_2a
-            | Self::Armv8_3a
-            | Self::Armv8_4a
-            | Self::Armv8_5a
-            | Self::Armv8mBase
-            | Self::Armv8mMain
-            | Self::Armv8r
-            | Self::Armebv7r
-            | Self::Thumbeb
-            | Self::Thumbv6m
-            | Self::Thumbv7a
-            | Self::Thumbv7em
-            | Self::Thumbv7m
-            | Self::Thumbv7neon
-            | Self::Thumbv8mBase
-            | Self::Thumbv8mMain => PointerWidth::U32,
+            Arm
+            | Armeb
+            | Armv4
+            | Armv4t
+            | Armv5t
+            | Armv5te
+            | Armv5tej
+            | Armv6
+            | Armv6j
+            | Armv6k
+            | Armv6z
+            | Armv6kz
+            | Armv6t2
+            | Armv6m
+            | Armv7
+            | Armv7a
+            | Armv7ve
+            | Armv7m
+            | Armv7r
+            | Armv7s
+            | Armv8
+            | Armv8a
+            | Armv8_1a
+            | Armv8_2a
+            | Armv8_3a
+            | Armv8_4a
+            | Armv8_5a
+            | Armv8mBase
+            | Armv8mMain
+            | Armv8r
+            | Armebv7r
+            | Thumbeb
+            | Thumbv6m
+            | Thumbv7a
+            | Thumbv7em
+            | Thumbv7m
+            | Thumbv7neon
+            | Thumbv8mBase
+            | Thumbv8mMain => PointerWidth::U32,
         }
     }
 
     /// Return the endianness of this architecture.
     pub fn endianness(self) -> Endianness {
+        use ArmArchitecture::*;
+
         match self {
-            Self::Arm
-            | Self::Armv4
-            | Self::Armv4t
-            | Self::Armv5t
-            | Self::Armv5te
-            | Self::Armv5tej
-            | Self::Armv6
-            | Self::Armv6j
-            | Self::Armv6k
-            | Self::Armv6z
-            | Self::Armv6kz
-            | Self::Armv6t2
-            | Self::Armv6m
-            | Self::Armv7
-            | Self::Armv7a
-            | Self::Armv7ve
-            | Self::Armv7m
-            | Self::Armv7r
-            | Self::Armv7s
-            | Self::Armv8
-            | Self::Armv8a
-            | Self::Armv8_1a
-            | Self::Armv8_2a
-            | Self::Armv8_3a
-            | Self::Armv8_4a
-            | Self::Armv8_5a
-            | Self::Armv8mBase
-            | Self::Armv8mMain
-            | Self::Armv8r
-            | Self::Thumbv6m
-            | Self::Thumbv7a
-            | Self::Thumbv7em
-            | Self::Thumbv7m
-            | Self::Thumbv7neon
-            | Self::Thumbv8mBase
-            | Self::Thumbv8mMain => Endianness::Little,
-            Self::Armeb | Self::Armebv7r | Self::Thumbeb => Endianness::Big,
+            Arm
+            | Armv4
+            | Armv4t
+            | Armv5t
+            | Armv5te
+            | Armv5tej
+            | Armv6
+            | Armv6j
+            | Armv6k
+            | Armv6z
+            | Armv6kz
+            | Armv6t2
+            | Armv6m
+            | Armv7
+            | Armv7a
+            | Armv7ve
+            | Armv7m
+            | Armv7r
+            | Armv7s
+            | Armv8
+            | Armv8a
+            | Armv8_1a
+            | Armv8_2a
+            | Armv8_3a
+            | Armv8_4a
+            | Armv8_5a
+            | Armv8mBase
+            | Armv8mMain
+            | Armv8r
+            | Thumbv6m
+            | Thumbv7a
+            | Thumbv7em
+            | Thumbv7m
+            | Thumbv7neon
+            | Thumbv8mBase
+            | Thumbv8mMain => Endianness::Little,
+            Armeb | Armebv7r | Thumbeb => Endianness::Big,
         }
     }
 }
@@ -259,7 +265,7 @@ impl Aarch64Architecture {
     /// Test if this architecture uses the Thumb instruction set.
     pub fn is_thumb(self) -> bool {
         match self {
-            Self::Aarch64 | Self::Aarch64be => false,
+            Aarch64Architecture::Aarch64 | Aarch64Architecture::Aarch64be => false,
         }
     }
 
@@ -270,15 +276,15 @@ impl Aarch64Architecture {
     /// Return the pointer bit width of this target's architecture.
     pub fn pointer_width(self) -> PointerWidth {
         match self {
-            Self::Aarch64 | Self::Aarch64be => PointerWidth::U64,
+            Aarch64Architecture::Aarch64 | Aarch64Architecture::Aarch64be => PointerWidth::U64,
         }
     }
 
     /// Return the endianness of this architecture.
     pub fn endianness(self) -> Endianness {
         match self {
-            Self::Aarch64 => Endianness::Little,
-            Self::Aarch64be => Endianness::Big,
+            Aarch64Architecture::Aarch64 => Endianness::Little,
+            Aarch64Architecture::Aarch64be => Endianness::Big,
         }
     }
 }
@@ -351,8 +357,8 @@ impl CustomVendor {
     /// Extracts a string slice.
     pub fn as_str(&self) -> &str {
         match self {
-            Self::Owned(s) => s,
-            Self::Static(s) => s,
+            CustomVendor::Owned(s) => s,
+            CustomVendor::Static(s) => s,
         }
     }
 }
@@ -481,65 +487,69 @@ pub enum BinaryFormat {
 impl Architecture {
     /// Return the endianness of this architecture.
     pub fn endianness(self) -> Result<Endianness, ()> {
+        use Architecture::*;
+
         match self {
-            Self::Unknown => Err(()),
-            Self::Arm(arm) => Ok(arm.endianness()),
-            Self::Aarch64(aarch) => Ok(aarch.endianness()),
-            Self::AmdGcn
-            | Self::Asmjs
-            | Self::Hexagon
-            | Self::X86_32(_)
-            | Self::Mips64(Mips64Architecture::Mips64el)
-            | Self::Mips32(Mips32Architecture::Mipsel)
-            | Self::Mips32(Mips32Architecture::Mipsisa32r6el)
-            | Self::Mips64(Mips64Architecture::Mipsisa64r6el)
-            | Self::Msp430
-            | Self::Nvptx64
-            | Self::Powerpc64le
-            | Self::Riscv32(_)
-            | Self::Riscv64(_)
-            | Self::Wasm32
-            | Self::Wasm64
-            | Self::X86_64 => Ok(Endianness::Little),
-            Self::Mips32(Mips32Architecture::Mips)
-            | Self::Mips64(Mips64Architecture::Mips64)
-            | Self::Mips32(Mips32Architecture::Mipsisa32r6)
-            | Self::Mips64(Mips64Architecture::Mipsisa64r6)
-            | Self::Powerpc
-            | Self::Powerpc64
-            | Self::S390x
-            | Self::Sparc
-            | Self::Sparc64
-            | Self::Sparcv9 => Ok(Endianness::Big),
+            Unknown => Err(()),
+            Arm(arm) => Ok(arm.endianness()),
+            Aarch64(aarch) => Ok(aarch.endianness()),
+            AmdGcn
+            | Asmjs
+            | Hexagon
+            | X86_32(_)
+            | Mips64(Mips64Architecture::Mips64el)
+            | Mips32(Mips32Architecture::Mipsel)
+            | Mips32(Mips32Architecture::Mipsisa32r6el)
+            | Mips64(Mips64Architecture::Mipsisa64r6el)
+            | Msp430
+            | Nvptx64
+            | Powerpc64le
+            | Riscv32(_)
+            | Riscv64(_)
+            | Wasm32
+            | Wasm64
+            | X86_64 => Ok(Endianness::Little),
+            Mips32(Mips32Architecture::Mips)
+            | Mips64(Mips64Architecture::Mips64)
+            | Mips32(Mips32Architecture::Mipsisa32r6)
+            | Mips64(Mips64Architecture::Mipsisa64r6)
+            | Powerpc
+            | Powerpc64
+            | S390x
+            | Sparc
+            | Sparc64
+            | Sparcv9 => Ok(Endianness::Big),
         }
     }
 
     /// Return the pointer bit width of this target's architecture.
     pub fn pointer_width(self) -> Result<PointerWidth, ()> {
+        use Architecture::*;
+
         match self {
-            Self::Unknown => Err(()),
-            Self::Msp430 => Ok(PointerWidth::U16),
-            Self::Arm(arm) => Ok(arm.pointer_width()),
-            Self::Aarch64(aarch) => Ok(aarch.pointer_width()),
-            Self::Asmjs
-            | Self::Hexagon
-            | Self::X86_32(_)
-            | Self::Riscv32(_)
-            | Self::Sparc
-            | Self::Wasm32
-            | Self::Mips32(_)
-            | Self::Powerpc => Ok(PointerWidth::U32),
-            Self::AmdGcn
-            | Self::Powerpc64le
-            | Self::Riscv64(_)
-            | Self::X86_64
-            | Self::Mips64(_)
-            | Self::Nvptx64
-            | Self::Powerpc64
-            | Self::S390x
-            | Self::Sparc64
-            | Self::Sparcv9
-            | Self::Wasm64 => Ok(PointerWidth::U64),
+            Unknown => Err(()),
+            Msp430 => Ok(PointerWidth::U16),
+            Arm(arm) => Ok(arm.pointer_width()),
+            Aarch64(aarch) => Ok(aarch.pointer_width()),
+            Asmjs
+            | Hexagon
+            | X86_32(_)
+            | Riscv32(_)
+            | Sparc
+            | Wasm32
+            | Mips32(_)
+            | Powerpc => Ok(PointerWidth::U32),
+            AmdGcn
+            | Powerpc64le
+            | Riscv64(_)
+            | X86_64
+            | Mips64(_)
+            | Nvptx64
+            | Powerpc64
+            | S390x
+            | Sparc64
+            | Sparcv9
+            | Wasm64 => Ok(PointerWidth::U64),
         }
     }
 }
@@ -570,46 +580,48 @@ pub(crate) fn default_binary_format(triple: &Triple) -> BinaryFormat {
 
 impl fmt::Display for ArmArchitecture {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use ArmArchitecture::*;
+
         let s = match *self {
-            Self::Arm => "arm",
-            Self::Armeb => "armeb",
-            Self::Armv4 => "armv4",
-            Self::Armv4t => "armv4t",
-            Self::Armv5t => "armv5t",
-            Self::Armv5te => "armv5te",
-            Self::Armv5tej => "armv5tej",
-            Self::Armv6 => "armv6",
-            Self::Armv6j => "armv6j",
-            Self::Armv6k => "armv6k",
-            Self::Armv6z => "armv6z",
-            Self::Armv6kz => "armv6kz",
-            Self::Armv6t2 => "armv6t2",
-            Self::Armv6m => "armv6m",
-            Self::Armv7 => "armv7",
-            Self::Armv7a => "armv7a",
-            Self::Armv7ve => "armv7ve",
-            Self::Armv7m => "armv7m",
-            Self::Armv7r => "armv7r",
-            Self::Armv7s => "armv7s",
-            Self::Armv8 => "armv8",
-            Self::Armv8a => "armv8a",
-            Self::Armv8_1a => "armv8.1a",
-            Self::Armv8_2a => "armv8.2a",
-            Self::Armv8_3a => "armv8.3a",
-            Self::Armv8_4a => "armv8.4a",
-            Self::Armv8_5a => "armv8.5a",
-            Self::Armv8mBase => "armv8m.base",
-            Self::Armv8mMain => "armv8m.main",
-            Self::Armv8r => "armv8r",
-            Self::Thumbeb => "thumbeb",
-            Self::Thumbv6m => "thumbv6m",
-            Self::Thumbv7a => "thumbv7a",
-            Self::Thumbv7em => "thumbv7em",
-            Self::Thumbv7m => "thumbv7m",
-            Self::Thumbv7neon => "thumbv7neon",
-            Self::Thumbv8mBase => "thumbv8m.base",
-            Self::Thumbv8mMain => "thumbv8m.main",
-            Self::Armebv7r => "armebv7r",
+            Arm => "arm",
+            Armeb => "armeb",
+            Armv4 => "armv4",
+            Armv4t => "armv4t",
+            Armv5t => "armv5t",
+            Armv5te => "armv5te",
+            Armv5tej => "armv5tej",
+            Armv6 => "armv6",
+            Armv6j => "armv6j",
+            Armv6k => "armv6k",
+            Armv6z => "armv6z",
+            Armv6kz => "armv6kz",
+            Armv6t2 => "armv6t2",
+            Armv6m => "armv6m",
+            Armv7 => "armv7",
+            Armv7a => "armv7a",
+            Armv7ve => "armv7ve",
+            Armv7m => "armv7m",
+            Armv7r => "armv7r",
+            Armv7s => "armv7s",
+            Armv8 => "armv8",
+            Armv8a => "armv8a",
+            Armv8_1a => "armv8.1a",
+            Armv8_2a => "armv8.2a",
+            Armv8_3a => "armv8.3a",
+            Armv8_4a => "armv8.4a",
+            Armv8_5a => "armv8.5a",
+            Armv8mBase => "armv8m.base",
+            Armv8mMain => "armv8m.main",
+            Armv8r => "armv8r",
+            Thumbeb => "thumbeb",
+            Thumbv6m => "thumbv6m",
+            Thumbv7a => "thumbv7a",
+            Thumbv7em => "thumbv7em",
+            Thumbv7m => "thumbv7m",
+            Thumbv7neon => "thumbv7neon",
+            Thumbv8mBase => "thumbv8m.base",
+            Thumbv8mMain => "thumbv8m.main",
+            Armebv7r => "armebv7r",
         };
         f.write_str(s)
     }
@@ -618,8 +630,8 @@ impl fmt::Display for ArmArchitecture {
 impl fmt::Display for Aarch64Architecture {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let s = match *self {
-            Self::Aarch64 => "aarch64",
-            Self::Aarch64be => "aarch64be",
+            Aarch64Architecture::Aarch64 => "aarch64",
+            Aarch64Architecture::Aarch64be => "aarch64be",
         };
         f.write_str(s)
     }
@@ -627,11 +639,13 @@ impl fmt::Display for Aarch64Architecture {
 
 impl fmt::Display for Riscv32Architecture {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use Riscv32Architecture::*;
+
         let s = match *self {
-            Self::Riscv32 => "riscv32",
-            Self::Riscv32i => "riscv32i",
-            Self::Riscv32imac => "riscv32imac",
-            Self::Riscv32imc => "riscv32imc",
+            Riscv32 => "riscv32",
+            Riscv32i => "riscv32i",
+            Riscv32imac => "riscv32imac",
+            Riscv32imc => "riscv32imc",
         };
         f.write_str(s)
     }
@@ -640,9 +654,9 @@ impl fmt::Display for Riscv32Architecture {
 impl fmt::Display for Riscv64Architecture {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let s = match *self {
-            Self::Riscv64 => "riscv64",
-            Self::Riscv64gc => "riscv64gc",
-            Self::Riscv64imac => "riscv64imac",
+            Riscv64Architecture::Riscv64 => "riscv64",
+            Riscv64Architecture::Riscv64gc => "riscv64gc",
+            Riscv64Architecture::Riscv64imac => "riscv64imac",
         };
         f.write_str(s)
     }
@@ -651,9 +665,9 @@ impl fmt::Display for Riscv64Architecture {
 impl fmt::Display for X86_32Architecture {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let s = match *self {
-            Self::I386 => "i386",
-            Self::I586 => "i586",
-            Self::I686 => "i686",
+            X86_32Architecture::I386 => "i386",
+            X86_32Architecture::I586 => "i586",
+            X86_32Architecture::I686 => "i686",
         };
         f.write_str(s)
     }
@@ -661,11 +675,13 @@ impl fmt::Display for X86_32Architecture {
 
 impl fmt::Display for Mips32Architecture {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use Mips32Architecture::*;
+
         let s = match *self {
-            Self::Mips => "mips",
-            Self::Mipsel => "mipsel",
-            Self::Mipsisa32r6 => "mipsisa32r6",
-            Self::Mipsisa32r6el => "mipsisa32r6el",
+            Mips => "mips",
+            Mipsel => "mipsel",
+            Mipsisa32r6 => "mipsisa32r6",
+            Mipsisa32r6el => "mipsisa32r6el",
         };
         f.write_str(s)
     }
@@ -673,11 +689,13 @@ impl fmt::Display for Mips32Architecture {
 
 impl fmt::Display for Mips64Architecture {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use Mips64Architecture::*;
+
         let s = match *self {
-            Self::Mips64 => "mips64",
-            Self::Mips64el => "mips64el",
-            Self::Mipsisa64r6 => "mipsisa64r6",
-            Self::Mipsisa64r6el => "mipsisa64r6el",
+            Mips64 => "mips64",
+            Mips64el => "mips64el",
+            Mipsisa64r6 => "mipsisa64r6",
+            Mipsisa64r6el => "mipsisa64r6el",
         };
         f.write_str(s)
     }
@@ -685,30 +703,32 @@ impl fmt::Display for Mips64Architecture {
 
 impl fmt::Display for Architecture {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use Architecture::*;
+
         match *self {
-            Self::Arm(arm) => arm.fmt(f),
-            Self::Aarch64(aarch) => aarch.fmt(f),
-            Self::Unknown => f.write_str("unknown"),
-            Self::AmdGcn => f.write_str("amdgcn"),
-            Self::Asmjs => f.write_str("asmjs"),
-            Self::Hexagon => f.write_str("hexagon"),
-            Self::X86_32(x86_32) => x86_32.fmt(f),
-            Self::Mips32(mips32) => mips32.fmt(f),
-            Self::Mips64(mips64) => mips64.fmt(f),
-            Self::Msp430 => f.write_str("msp430"),
-            Self::Nvptx64 => f.write_str("nvptx64"),
-            Self::Powerpc => f.write_str("powerpc"),
-            Self::Powerpc64 => f.write_str("powerpc64"),
-            Self::Powerpc64le => f.write_str("powerpc64le"),
-            Self::Riscv32(riscv32) => riscv32.fmt(f),
-            Self::Riscv64(riscv64) => riscv64.fmt(f),
-            Self::S390x => f.write_str("s390x"),
-            Self::Sparc => f.write_str("sparc"),
-            Self::Sparc64 => f.write_str("sparc64"),
-            Self::Sparcv9 => f.write_str("sparcv9"),
-            Self::Wasm32 => f.write_str("wasm32"),
-            Self::Wasm64 => f.write_str("wasm64"),
-            Self::X86_64 => f.write_str("x86_64"),
+            Arm(arm) => arm.fmt(f),
+            Aarch64(aarch) => aarch.fmt(f),
+            Unknown => f.write_str("unknown"),
+            AmdGcn => f.write_str("amdgcn"),
+            Asmjs => f.write_str("asmjs"),
+            Hexagon => f.write_str("hexagon"),
+            X86_32(x86_32) => x86_32.fmt(f),
+            Mips32(mips32) => mips32.fmt(f),
+            Mips64(mips64) => mips64.fmt(f),
+            Msp430 => f.write_str("msp430"),
+            Nvptx64 => f.write_str("nvptx64"),
+            Powerpc => f.write_str("powerpc"),
+            Powerpc64 => f.write_str("powerpc64"),
+            Powerpc64le => f.write_str("powerpc64le"),
+            Riscv32(riscv32) => riscv32.fmt(f),
+            Riscv64(riscv64) => riscv64.fmt(f),
+            S390x => f.write_str("s390x"),
+            Sparc => f.write_str("sparc"),
+            Sparc64 => f.write_str("sparc64"),
+            Sparcv9 => f.write_str("sparcv9"),
+            Wasm32 => f.write_str("wasm32"),
+            Wasm64 => f.write_str("wasm64"),
+            X86_64 => f.write_str("x86_64"),
         }
     }
 }
@@ -717,46 +737,48 @@ impl FromStr for ArmArchitecture {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, ()> {
+        use ArmArchitecture::*;
+
         Ok(match s {
-            "arm" => Self::Arm,
-            "armeb" => Self::Armeb,
-            "armv4" => Self::Armv4,
-            "armv4t" => Self::Armv4t,
-            "armv5t" => Self::Armv5t,
-            "armv5te" => Self::Armv5te,
-            "armv5tej" => Self::Armv5tej,
-            "armv6" => Self::Armv6,
-            "armv6j" => Self::Armv6j,
-            "armv6k" => Self::Armv6k,
-            "armv6z" => Self::Armv6z,
-            "armv6kz" => Self::Armv6kz,
-            "armv6t2" => Self::Armv6t2,
-            "armv6m" => Self::Armv6m,
-            "armv7" => Self::Armv7,
-            "armv7a" => Self::Armv7a,
-            "armv7ve" => Self::Armv7ve,
-            "armv7m" => Self::Armv7m,
-            "armv7r" => Self::Armv7r,
-            "armv7s" => Self::Armv7s,
-            "armv8" => Self::Armv8,
-            "armv8a" => Self::Armv8a,
-            "armv8.1a" => Self::Armv8_1a,
-            "armv8.2a" => Self::Armv8_2a,
-            "armv8.3a" => Self::Armv8_3a,
-            "armv8.4a" => Self::Armv8_4a,
-            "armv8.5a" => Self::Armv8_5a,
-            "armv8m.base" => Self::Armv8mBase,
-            "armv8m.main" => Self::Armv8mMain,
-            "armv8r" => Self::Armv8r,
-            "thumbeb" => Self::Thumbeb,
-            "thumbv6m" => Self::Thumbv6m,
-            "thumbv7a" => Self::Thumbv7a,
-            "thumbv7em" => Self::Thumbv7em,
-            "thumbv7m" => Self::Thumbv7m,
-            "thumbv7neon" => Self::Thumbv7neon,
-            "thumbv8m.base" => Self::Thumbv8mBase,
-            "thumbv8m.main" => Self::Thumbv8mMain,
-            "armebv7r" => Self::Armebv7r,
+            "arm" => Arm,
+            "armeb" => Armeb,
+            "armv4" => Armv4,
+            "armv4t" => Armv4t,
+            "armv5t" => Armv5t,
+            "armv5te" => Armv5te,
+            "armv5tej" => Armv5tej,
+            "armv6" => Armv6,
+            "armv6j" => Armv6j,
+            "armv6k" => Armv6k,
+            "armv6z" => Armv6z,
+            "armv6kz" => Armv6kz,
+            "armv6t2" => Armv6t2,
+            "armv6m" => Armv6m,
+            "armv7" => Armv7,
+            "armv7a" => Armv7a,
+            "armv7ve" => Armv7ve,
+            "armv7m" => Armv7m,
+            "armv7r" => Armv7r,
+            "armv7s" => Armv7s,
+            "armv8" => Armv8,
+            "armv8a" => Armv8a,
+            "armv8.1a" => Armv8_1a,
+            "armv8.2a" => Armv8_2a,
+            "armv8.3a" => Armv8_3a,
+            "armv8.4a" => Armv8_4a,
+            "armv8.5a" => Armv8_5a,
+            "armv8m.base" => Armv8mBase,
+            "armv8m.main" => Armv8mMain,
+            "armv8r" => Armv8r,
+            "thumbeb" => Thumbeb,
+            "thumbv6m" => Thumbv6m,
+            "thumbv7a" => Thumbv7a,
+            "thumbv7em" => Thumbv7em,
+            "thumbv7m" => Thumbv7m,
+            "thumbv7neon" => Thumbv7neon,
+            "thumbv8m.base" => Thumbv8mBase,
+            "thumbv8m.main" => Thumbv8mMain,
+            "armebv7r" => Armebv7r,
             _ => return Err(()),
         })
     }
@@ -766,10 +788,12 @@ impl FromStr for Aarch64Architecture {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, ()> {
+        use Aarch64Architecture::*;
+
         Ok(match s {
-            "aarch64" => Self::Aarch64,
-            "arm64" => Self::Aarch64,
-            "aarch64be" => Self::Aarch64be,
+            "aarch64" => Aarch64,
+            "arm64" => Aarch64,
+            "aarch64be" => Aarch64be,
             _ => return Err(()),
         })
     }
@@ -779,11 +803,13 @@ impl FromStr for Riscv32Architecture {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, ()> {
+        use Riscv32Architecture::*;
+
         Ok(match s {
-            "riscv32" => Self::Riscv32,
-            "riscv32i" => Self::Riscv32i,
-            "riscv32imac" => Self::Riscv32imac,
-            "riscv32imc" => Self::Riscv32imc,
+            "riscv32" => Riscv32,
+            "riscv32i" => Riscv32i,
+            "riscv32imac" => Riscv32imac,
+            "riscv32imc" => Riscv32imc,
             _ => return Err(()),
         })
     }
@@ -793,10 +819,12 @@ impl FromStr for Riscv64Architecture {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, ()> {
+        use Riscv64Architecture::*;
+
         Ok(match s {
-            "riscv64" => Self::Riscv64,
-            "riscv64gc" => Self::Riscv64gc,
-            "riscv64imac" => Self::Riscv64imac,
+            "riscv64" => Riscv64,
+            "riscv64gc" => Riscv64gc,
+            "riscv64imac" => Riscv64imac,
             _ => return Err(()),
         })
     }
@@ -806,10 +834,12 @@ impl FromStr for X86_32Architecture {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, ()> {
+        use X86_32Architecture::*;
+
         Ok(match s {
-            "i386" => Self::I386,
-            "i586" => Self::I586,
-            "i686" => Self::I686,
+            "i386" => I386,
+            "i586" => I586,
+            "i686" => I686,
             _ => return Err(()),
         })
     }
@@ -819,11 +849,13 @@ impl FromStr for Mips32Architecture {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, ()> {
+        use Mips32Architecture::*;
+
         Ok(match s {
-            "mips" => Self::Mips,
-            "mipsel" => Self::Mipsel,
-            "mipsisa32r6" => Self::Mipsisa32r6,
-            "mipsisa32r6el" => Self::Mipsisa32r6el,
+            "mips" => Mips,
+            "mipsel" => Mipsel,
+            "mipsisa32r6" => Mipsisa32r6,
+            "mipsisa32r6el" => Mipsisa32r6el,
             _ => return Err(()),
         })
     }
@@ -833,11 +865,13 @@ impl FromStr for Mips64Architecture {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, ()> {
+        use Mips64Architecture::*;
+
         Ok(match s {
-            "mips64" => Self::Mips64,
-            "mips64el" => Self::Mips64el,
-            "mipsisa64r6" => Self::Mipsisa64r6,
-            "mipsisa64r6el" => Self::Mipsisa64r6el,
+            "mips64" => Mips64,
+            "mips64el" => Mips64el,
+            "mipsisa64r6" => Mipsisa64r6,
+            "mipsisa64r6el" => Mipsisa64r6el,
             _ => return Err(()),
         })
     }
@@ -847,38 +881,40 @@ impl FromStr for Architecture {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, ()> {
+        use Architecture::*;
+
         Ok(match s {
-            "unknown" => Self::Unknown,
-            "amdgcn" => Self::AmdGcn,
-            "asmjs" => Self::Asmjs,
-            "hexagon" => Self::Hexagon,
-            "msp430" => Self::Msp430,
-            "nvptx64" => Self::Nvptx64,
-            "powerpc" => Self::Powerpc,
-            "powerpc64" => Self::Powerpc64,
-            "powerpc64le" => Self::Powerpc64le,
-            "s390x" => Self::S390x,
-            "sparc" => Self::Sparc,
-            "sparc64" => Self::Sparc64,
-            "sparcv9" => Self::Sparcv9,
-            "wasm32" => Self::Wasm32,
-            "wasm64" => Self::Wasm64,
-            "x86_64" => Self::X86_64,
+            "unknown" => Unknown,
+            "amdgcn" => AmdGcn,
+            "asmjs" => Asmjs,
+            "hexagon" => Hexagon,
+            "msp430" => Msp430,
+            "nvptx64" => Nvptx64,
+            "powerpc" => Powerpc,
+            "powerpc64" => Powerpc64,
+            "powerpc64le" => Powerpc64le,
+            "s390x" => S390x,
+            "sparc" => Sparc,
+            "sparc64" => Sparc64,
+            "sparcv9" => Sparcv9,
+            "wasm32" => Wasm32,
+            "wasm64" => Wasm64,
+            "x86_64" => X86_64,
             _ => {
                 if let Ok(arm) = ArmArchitecture::from_str(s) {
-                    Self::Arm(arm)
+                    Arm(arm)
                 } else if let Ok(aarch64) = Aarch64Architecture::from_str(s) {
-                    Self::Aarch64(aarch64)
+                    Aarch64(aarch64)
                 } else if let Ok(riscv32) = Riscv32Architecture::from_str(s) {
-                    Self::Riscv32(riscv32)
+                    Riscv32(riscv32)
                 } else if let Ok(riscv64) = Riscv64Architecture::from_str(s) {
-                    Self::Riscv64(riscv64)
+                    Riscv64(riscv64)
                 } else if let Ok(x86_32) = X86_32Architecture::from_str(s) {
-                    Self::X86_32(x86_32)
+                    X86_32(x86_32)
                 } else if let Ok(mips32) = Mips32Architecture::from_str(s) {
-                    Self::Mips32(mips32)
+                    Mips32(mips32)
                 } else if let Ok(mips64) = Mips64Architecture::from_str(s) {
-                    Self::Mips64(mips64)
+                    Mips64(mips64)
                 } else {
                     return Err(());
                 }
@@ -889,19 +925,21 @@ impl FromStr for Architecture {
 
 impl fmt::Display for Vendor {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use Vendor::*;
+
         let s = match *self {
-            Self::Unknown => "unknown",
-            Self::Amd => "amd",
-            Self::Apple => "apple",
-            Self::Experimental => "experimental",
-            Self::Fortanix => "fortanix",
-            Self::Nvidia => "nvidia",
-            Self::Pc => "pc",
-            Self::Rumprun => "rumprun",
-            Self::Sun => "sun",
-            Self::Uwp => "uwp",
-            Self::Wrs => "wrs",
-            Self::Custom(ref name) => name.as_str(),
+            Unknown => "unknown",
+            Amd => "amd",
+            Apple => "apple",
+            Experimental => "experimental",
+            Fortanix => "fortanix",
+            Nvidia => "nvidia",
+            Pc => "pc",
+            Rumprun => "rumprun",
+            Sun => "sun",
+            Uwp => "uwp",
+            Wrs => "wrs",
+            Custom(ref name) => name.as_str(),
         };
         f.write_str(s)
     }
@@ -911,18 +949,20 @@ impl FromStr for Vendor {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, ()> {
+        use Vendor::*;
+
         Ok(match s {
-            "unknown" => Self::Unknown,
-            "amd" => Self::Amd,
-            "apple" => Self::Apple,
-            "experimental" => Self::Experimental,
-            "fortanix" => Self::Fortanix,
-            "nvidia" => Self::Nvidia,
-            "pc" => Self::Pc,
-            "rumprun" => Self::Rumprun,
-            "sun" => Self::Sun,
-            "uwp" => Self::Uwp,
-            "wrs" => Self::Wrs,
+            "unknown" => Unknown,
+            "amd" => Amd,
+            "apple" => Apple,
+            "experimental" => Experimental,
+            "fortanix" => Fortanix,
+            "nvidia" => Nvidia,
+            "pc" => Pc,
+            "rumprun" => Rumprun,
+            "sun" => Sun,
+            "uwp" => Uwp,
+            "wrs" => Wrs,
             custom => {
                 use alloc::borrow::ToOwned;
 
@@ -960,7 +1000,7 @@ impl FromStr for Vendor {
                     return Err(());
                 }
 
-                Self::Custom(CustomVendor::Owned(Box::new(custom.to_owned())))
+                Custom(CustomVendor::Owned(Box::new(custom.to_owned())))
             }
         })
     }
@@ -968,41 +1008,43 @@ impl FromStr for Vendor {
 
 impl fmt::Display for OperatingSystem {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use OperatingSystem::*;
+
         let s = match *self {
-            Self::Unknown => "unknown",
-            Self::AmdHsa => "amdhsa",
-            Self::Bitrig => "bitrig",
-            Self::Cloudabi => "cloudabi",
-            Self::Cuda => "cuda",
-            Self::Darwin => "darwin",
-            Self::Dragonfly => "dragonfly",
-            Self::Emscripten => "emscripten",
-            Self::Freebsd => "freebsd",
-            Self::Fuchsia => "fuchsia",
-            Self::Haiku => "haiku",
-            Self::Hermit => "hermit",
-            Self::Illumos => "illumos",
-            Self::Ios => "ios",
-            Self::L4re => "l4re",
-            Self::Linux => "linux",
-            Self::MacOSX {
+            Unknown => "unknown",
+            AmdHsa => "amdhsa",
+            Bitrig => "bitrig",
+            Cloudabi => "cloudabi",
+            Cuda => "cuda",
+            Darwin => "darwin",
+            Dragonfly => "dragonfly",
+            Emscripten => "emscripten",
+            Freebsd => "freebsd",
+            Fuchsia => "fuchsia",
+            Haiku => "haiku",
+            Hermit => "hermit",
+            Illumos => "illumos",
+            Ios => "ios",
+            L4re => "l4re",
+            Linux => "linux",
+            MacOSX {
                 major,
                 minor,
                 patch,
             } => {
                 return write!(f, "macosx{}.{}.{}", major, minor, patch);
             }
-            Self::Nebulet => "nebulet",
-            Self::Netbsd => "netbsd",
-            Self::None_ => "none",
-            Self::Openbsd => "openbsd",
-            Self::Psp => "psp",
-            Self::Redox => "redox",
-            Self::Solaris => "solaris",
-            Self::Uefi => "uefi",
-            Self::VxWorks => "vxworks",
-            Self::Wasi => "wasi",
-            Self::Windows => "windows",
+            Nebulet => "nebulet",
+            Netbsd => "netbsd",
+            None_ => "none",
+            Openbsd => "openbsd",
+            Psp => "psp",
+            Redox => "redox",
+            Solaris => "solaris",
+            Uefi => "uefi",
+            VxWorks => "vxworks",
+            Wasi => "wasi",
+            Windows => "windows",
         };
         f.write_str(s)
     }
@@ -1012,6 +1054,8 @@ impl FromStr for OperatingSystem {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, ()> {
+        use OperatingSystem::*;
+
         // TODO also parse version number for darwin and ios OSes
         if s.starts_with("macosx") {
             // Parse operating system names like `macosx10.7.0`.
@@ -1036,7 +1080,7 @@ impl FromStr for OperatingSystem {
                 return Err(());
             }
 
-            return Ok(Self::MacOSX {
+            return Ok(MacOSX {
                 major,
                 minor,
                 patch,
@@ -1044,33 +1088,33 @@ impl FromStr for OperatingSystem {
         }
 
         Ok(match s {
-            "unknown" => Self::Unknown,
-            "amdhsa" => Self::AmdHsa,
-            "bitrig" => Self::Bitrig,
-            "cloudabi" => Self::Cloudabi,
-            "cuda" => Self::Cuda,
-            "darwin" => Self::Darwin,
-            "dragonfly" => Self::Dragonfly,
-            "emscripten" => Self::Emscripten,
-            "freebsd" => Self::Freebsd,
-            "fuchsia" => Self::Fuchsia,
-            "haiku" => Self::Haiku,
-            "hermit" => Self::Hermit,
-            "illumos" => Self::Illumos,
-            "ios" => Self::Ios,
-            "l4re" => Self::L4re,
-            "linux" => Self::Linux,
-            "nebulet" => Self::Nebulet,
-            "netbsd" => Self::Netbsd,
-            "none" => Self::None_,
-            "openbsd" => Self::Openbsd,
-            "psp" => Self::Psp,
-            "redox" => Self::Redox,
-            "solaris" => Self::Solaris,
-            "uefi" => Self::Uefi,
-            "vxworks" => Self::VxWorks,
-            "wasi" => Self::Wasi,
-            "windows" => Self::Windows,
+            "unknown" => Unknown,
+            "amdhsa" => AmdHsa,
+            "bitrig" => Bitrig,
+            "cloudabi" => Cloudabi,
+            "cuda" => Cuda,
+            "darwin" => Darwin,
+            "dragonfly" => Dragonfly,
+            "emscripten" => Emscripten,
+            "freebsd" => Freebsd,
+            "fuchsia" => Fuchsia,
+            "haiku" => Haiku,
+            "hermit" => Hermit,
+            "illumos" => Illumos,
+            "ios" => Ios,
+            "l4re" => L4re,
+            "linux" => Linux,
+            "nebulet" => Nebulet,
+            "netbsd" => Netbsd,
+            "none" => None_,
+            "openbsd" => Openbsd,
+            "psp" => Psp,
+            "redox" => Redox,
+            "solaris" => Solaris,
+            "uefi" => Uefi,
+            "vxworks" => VxWorks,
+            "wasi" => Wasi,
+            "windows" => Windows,
             _ => return Err(()),
         })
     }
@@ -1078,30 +1122,32 @@ impl FromStr for OperatingSystem {
 
 impl fmt::Display for Environment {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use Environment::*;
+
         let s = match *self {
-            Self::Unknown => "unknown",
-            Self::AmdGiz => "amdgiz",
-            Self::Android => "android",
-            Self::Androideabi => "androideabi",
-            Self::Eabi => "eabi",
-            Self::Eabihf => "eabihf",
-            Self::Gnu => "gnu",
-            Self::Gnuabi64 => "gnuabi64",
-            Self::Gnueabi => "gnueabi",
-            Self::Gnueabihf => "gnueabihf",
-            Self::Gnuspe => "gnuspe",
-            Self::Gnux32 => "gnux32",
-            Self::Macabi => "macabi",
-            Self::Musl => "musl",
-            Self::Musleabi => "musleabi",
-            Self::Musleabihf => "musleabihf",
-            Self::Muslabi64 => "muslabi64",
-            Self::Msvc => "msvc",
-            Self::Kernel => "kernel",
-            Self::Uclibc => "uclibc",
-            Self::Sgx => "sgx",
-            Self::Softfloat => "softfloat",
-            Self::Spe => "spe",
+            Unknown => "unknown",
+            AmdGiz => "amdgiz",
+            Android => "android",
+            Androideabi => "androideabi",
+            Eabi => "eabi",
+            Eabihf => "eabihf",
+            Gnu => "gnu",
+            Gnuabi64 => "gnuabi64",
+            Gnueabi => "gnueabi",
+            Gnueabihf => "gnueabihf",
+            Gnuspe => "gnuspe",
+            Gnux32 => "gnux32",
+            Macabi => "macabi",
+            Musl => "musl",
+            Musleabi => "musleabi",
+            Musleabihf => "musleabihf",
+            Muslabi64 => "muslabi64",
+            Msvc => "msvc",
+            Kernel => "kernel",
+            Uclibc => "uclibc",
+            Sgx => "sgx",
+            Softfloat => "softfloat",
+            Spe => "spe",
         };
         f.write_str(s)
     }
@@ -1111,30 +1157,32 @@ impl FromStr for Environment {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, ()> {
+        use Environment::*;
+
         Ok(match s {
-            "unknown" => Self::Unknown,
-            "amdgiz" => Self::AmdGiz,
-            "android" => Self::Android,
-            "androideabi" => Self::Androideabi,
-            "eabi" => Self::Eabi,
-            "eabihf" => Self::Eabihf,
-            "gnu" => Self::Gnu,
-            "gnuabi64" => Self::Gnuabi64,
-            "gnueabi" => Self::Gnueabi,
-            "gnueabihf" => Self::Gnueabihf,
-            "gnuspe" => Self::Gnuspe,
-            "gnux32" => Self::Gnux32,
-            "macabi" => Self::Macabi,
-            "musl" => Self::Musl,
-            "musleabi" => Self::Musleabi,
-            "musleabihf" => Self::Musleabihf,
-            "muslabi64" => Self::Muslabi64,
-            "msvc" => Self::Msvc,
-            "kernel" => Self::Kernel,
-            "uclibc" => Self::Uclibc,
-            "sgx" => Self::Sgx,
-            "softfloat" => Self::Softfloat,
-            "spe" => Self::Spe,
+            "unknown" => Unknown,
+            "amdgiz" => AmdGiz,
+            "android" => Android,
+            "androideabi" => Androideabi,
+            "eabi" => Eabi,
+            "eabihf" => Eabihf,
+            "gnu" => Gnu,
+            "gnuabi64" => Gnuabi64,
+            "gnueabi" => Gnueabi,
+            "gnueabihf" => Gnueabihf,
+            "gnuspe" => Gnuspe,
+            "gnux32" => Gnux32,
+            "macabi" => Macabi,
+            "musl" => Musl,
+            "musleabi" => Musleabi,
+            "musleabihf" => Musleabihf,
+            "muslabi64" => Muslabi64,
+            "msvc" => Msvc,
+            "kernel" => Kernel,
+            "uclibc" => Uclibc,
+            "sgx" => Sgx,
+            "softfloat" => Softfloat,
+            "spe" => Spe,
             _ => return Err(()),
         })
     }
@@ -1142,12 +1190,14 @@ impl FromStr for Environment {
 
 impl fmt::Display for BinaryFormat {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use BinaryFormat::*;
+
         let s = match *self {
-            Self::Unknown => "unknown",
-            Self::Elf => "elf",
-            Self::Coff => "coff",
-            Self::Macho => "macho",
-            Self::Wasm => "wasm",
+            Unknown => "unknown",
+            Elf => "elf",
+            Coff => "coff",
+            Macho => "macho",
+            Wasm => "wasm",
         };
         f.write_str(s)
     }
@@ -1157,12 +1207,14 @@ impl FromStr for BinaryFormat {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, ()> {
+        use BinaryFormat::*;
+
         Ok(match s {
-            "unknown" => Self::Unknown,
-            "elf" => Self::Elf,
-            "coff" => Self::Coff,
-            "macho" => Self::Macho,
-            "wasm" => Self::Wasm,
+            "unknown" => Unknown,
+            "elf" => Elf,
+            "coff" => Coff,
+            "macho" => Macho,
+            "wasm" => Wasm,
             _ => return Err(()),
         })
     }

--- a/src/triple.rs
+++ b/src/triple.rs
@@ -31,9 +31,9 @@ impl PointerWidth {
     /// Return the number of bits in a pointer.
     pub fn bits(self) -> u8 {
         match self {
-            Self::U16 => 16,
-            Self::U32 => 32,
-            Self::U64 => 64,
+            PointerWidth::U16 => 16,
+            PointerWidth::U32 => 32,
+            PointerWidth::U64 => 64,
         }
     }
 
@@ -42,9 +42,9 @@ impl PointerWidth {
     /// For these purposes, there are 8 bits in a byte.
     pub fn bytes(self) -> u8 {
         match self {
-            Self::U16 => 2,
-            Self::U32 => 4,
-            Self::U64 => 8,
+            PointerWidth::U16 => 2,
+            PointerWidth::U32 => 4,
+            PointerWidth::U64 => 8,
         }
     }
 }


### PR DESCRIPTION
- Change `Self::Variant` to `T::Variant`
- Use `extern crate alloc;` only with `no_std`. `no_std` and 1.34 are not supported
- Detect whether using rust 1.40 or greater in `build.rs`. If so, use `#[non_exhaustive]` on enums.
- Add 1.34.0 to CI

Closes https://github.com/bytecodealliance/target-lexicon/issues/58.