### PR TITLE
Fix 1.34 support

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -59,10 +59,16 @@ fn main() {
 fn using_1_40() -> bool {
     match (|| {
         let stdout = match Command::new("rustc").arg("--version").output() {
-            Ok(output) if output.status.success() => output.stdout,
+            Ok(output) => {
+                if output.status.success() {
+                    output.stdout
+                } else {
+                    return None;
+                }
+            }
             _ => return None,
         };
-        std::str::from_utf8(&stdout).ok()?.split(' ').nth(1)?.parse::<i32>().ok()
+        std::str::from_utf8(&stdout).ok()?.split(' ').nth(1)?.split('.').nth(1)?.parse::<i32>().ok()
     })() {
         Some(version) => version >= 40,
         None => true, // assume we're using an up-to-date compiler


### PR DESCRIPTION
It turns out it didn't actually work, the logic in `using_1_40` was wrong. I didn't notice because I only tested with 1.40 after addressing review comments.

I guess that means that the 1.34 check in CI didn't run? Is there a way to set that up? Otherwise I'm worried people will accidentally change the minimum version without meaning to.