### PR TITLE
Fix build when vendor is unknown

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -222,7 +222,7 @@ fn write_host_rs(mut out: File, triple: Triple) -> io::Result<()> {
 
 fn vendor_display(vendor: &Vendor) -> String {
     match vendor {
-        Vendor::Custom(custom) => format!("CustomVendor::Static({:?})", custom.as_str()),
+        Vendor::Custom(custom) => format!("Custom(CustomVendor::Static({:?}))", custom.as_str()),
         known => format!("{:?}", known),
     }
 }


### PR DESCRIPTION
When the vendor is not recognized, the build script generates `Vendor::CustomVendor::Static("foo")`. This isn't valid.
This PR fixes it to `Vendor::Custom(CustomVendor::Static("foo"))`, as I suppose it's intended.