### PR TITLE
DefaultTo* structs derive Clone, Debug, etc.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ pub use self::triple::{CallingConvention, Endianness, PointerWidth, Triple};
 
 /// A simple wrapper around `Triple` that provides an implementation of
 /// `Default` which defaults to `Triple::host()`.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct DefaultToHost(pub Triple);
 
 impl Default for DefaultToHost {
@@ -50,6 +51,7 @@ impl Default for DefaultToHost {
 
 /// A simple wrapper around `Triple` that provides an implementation of
 /// `Default` which defaults to `Triple::unknown()`.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct DefaultToUnknown(pub Triple);
 
 impl Default for DefaultToUnknown {


### PR DESCRIPTION
When using either `DefaultToHost` or `DefaultToUnknown` structs (which are named tuples with `Default` implementations), the developer loses the benefits of being able to use them in `Clone`, `Debug`, `PartialEq`, `Eq`, and `Hash` contexts.

This commit adds the `#[derive]` macros to these structs to retain these traits from `Triple`.