### PR TITLE
Add Clever architecture

### DIFF
--- a/src/targets.rs
+++ b/src/targets.rs
@@ -1027,7 +1027,7 @@ impl FromStr for Architecture {
                     Mips32(mips32)
                 } else if let Ok(mips64) = Mips64Architecture::from_str(s) {
                     Mips64(mips64)
-                } else if let Ok(clever) = CleverArchitecture::from_str(s)){
+                } else if let Ok(clever) = CleverArchitecture::from_str(s){
                     Clever(clever)
                 } else {
                     return Err(());

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -41,7 +41,7 @@ pub enum Architecture {
     Wasm64,
     X86_64,
     XTensa,
-    Clever,
+    Clever(CleverArchitecture),
 }
 
 #[cfg_attr(feature = "rust_1_40", non_exhaustive)]
@@ -310,6 +310,16 @@ impl Aarch64Architecture {
     }
 }
 
+#[cfg_attr(feature = "rust_1_40", non_exhaustive)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[allow(missing_docs)]
+pub enum CleverArchitecture{
+    Clever,
+    Clever1_0,
+    // clever1.1.. is valid to parse. 
+    CleverFuture(Cow<str>),
+}
+
 /// An enum for all 32-bit RISC-V architectures.
 #[cfg_attr(feature = "rust_1_40", non_exhaustive)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
@@ -551,7 +561,8 @@ impl Architecture {
             | Wasm32
             | Wasm64
             | X86_64
-            | XTensa => Ok(Endianness::Little),
+            | XTensa
+            | Clever(_) => Ok(Endianness::Little),
             Bpfeb
             | M68k
             | Mips32(Mips32Architecture::Mips)
@@ -599,7 +610,8 @@ impl Architecture {
             | S390x
             | Sparc64
             | Sparcv9
-            | Wasm64 => Ok(PointerWidth::U64),
+            | Wasm64
+            | Clever(_) => Ok(PointerWidth::U64),
         }
     }
 }
@@ -689,6 +701,19 @@ impl fmt::Display for Aarch64Architecture {
             Aarch64Architecture::Aarch64be => "aarch64_be",
         };
         f.write_str(s)
+    }
+}
+
+impl fmt::Display for CleverArchitecture{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result{
+        match self{
+            Self::Clever => f.write_str("clever"),
+            Self::Clever1_0 => f.write_str("clever1.0"),
+            Self::CleverFuture(ver) => {
+                f.write_str("clever")?;
+                f.write_str(ver)
+            }
+        }
     }
 }
 
@@ -791,7 +816,7 @@ impl fmt::Display for Architecture {
             Wasm64 => f.write_str("wasm64"),
             X86_64 => f.write_str("x86_64"),
             XTensa => f.write_str("xtensa"),
-            Clever => f.write_str("clever"),
+            Clever(ver) => ver.fmt(f),
         }
     }
 }
@@ -862,6 +887,20 @@ impl FromStr for Aarch64Architecture {
             "aarch64_be" => Aarch64be,
             _ => return Err(()),
         })
+    }
+}
+
+impl FromStr for CleverArchitecture{
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, ()>{
+        match s{
+            "clever" => Ok(Self::Clever),
+            "clever1.0" => Ok(Self::Clever1_0),
+            x if x.starts_with("clever") => {
+                let x = &x[5..];
+                Ok(Self::CleverFuture(Cow::Owned(x.to_string())))
+            }
+        }
     }
 }
 
@@ -988,8 +1027,8 @@ impl FromStr for Architecture {
                     Mips32(mips32)
                 } else if let Ok(mips64) = Mips64Architecture::from_str(s) {
                     Mips64(mips64)
-                } else if s.starts_with("clever"){
-                    Clever
+                } else if let Ok(clever) = CleverArchitecture::from_str(s)){
+                    Clever(clever)
                 } else {
                     return Err(());
                 }

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -574,6 +574,7 @@ impl Architecture {
             | Sparc64
             | Sparcv9 => Ok(Endianness::Big),
         }
+
     }
 
     /// Return the pointer bit width of this target's architecture.
@@ -610,6 +611,14 @@ impl Architecture {
             | Sparcv9
             | Wasm64
             | Clever(_) => Ok(PointerWidth::U64),
+        }
+    }
+
+    /// Checks if this Architecture is some variant of Clever-ISA
+    pub fn is_clever(&self) -> bool {
+        match self {
+            Architecture::Clever(_) => true,
+            _ => false,
         }
     }
 }

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -41,6 +41,7 @@ pub enum Architecture {
     Wasm64,
     X86_64,
     XTensa,
+    Clever,
 }
 
 #[cfg_attr(feature = "rust_1_40", non_exhaustive)]
@@ -790,6 +791,7 @@ impl fmt::Display for Architecture {
             Wasm64 => f.write_str("wasm64"),
             X86_64 => f.write_str("x86_64"),
             XTensa => f.write_str("xtensa"),
+            Clever => f.write_str("clever"),
         }
     }
 }
@@ -986,6 +988,8 @@ impl FromStr for Architecture {
                     Mips32(mips32)
                 } else if let Ok(mips64) = Mips64Architecture::from_str(s) {
                     Mips64(mips64)
+                } else if s.starts_with("clever"){
+                    Clever
                 } else {
                     return Err(());
                 }
@@ -1547,6 +1551,7 @@ mod tests {
             "x86_64-uwp-windows-msvc",
             "x86_64-wrs-vxworks",
             "xtensa-esp32-espidf",
+            "clever-unknown-elf"
         ];
 
         for target in targets.iter() {

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -1581,6 +1581,7 @@ mod tests {
             "x86_64-uwp-windows-msvc",
             "x86_64-wrs-vxworks",
             "xtensa-esp32-espidf",
+            "clever-unknown-none",
         ];
 
         for target in targets.iter() {

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -6,6 +6,7 @@ use alloc::string::String;
 use core::fmt;
 use core::hash::{Hash, Hasher};
 use core::str::FromStr;
+use alloc::borrow::Cow;
 
 /// The "architecture" field, which in some cases also specifies a specific
 /// subarchitecture.

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -1581,7 +1581,7 @@ mod tests {
             "x86_64-uwp-windows-msvc",
             "x86_64-wrs-vxworks",
             "xtensa-esp32-espidf",
-            "clever-unknown-none",
+            "clever-unknown-elf",
         ];
 
         for target in targets.iter() {

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -888,8 +888,8 @@ impl FromStr for CleverArchitecture {
     type Err = ();
     fn from_str(s: &str) -> Result<Self, ()> {
         match s {
-            "clever" => Ok(Self::Clever),
-            "clever1.0" => Ok(Self::Clever1_0),
+            "clever" => Ok(CleverArchitecture::Clever),
+            "clever1.0" => Ok(CleverArchitecture::Clever1_0),
             _ => Err(()),
         }
     }
@@ -1581,7 +1581,6 @@ mod tests {
             "x86_64-uwp-windows-msvc",
             "x86_64-wrs-vxworks",
             "xtensa-esp32-espidf",
-            "clever-unknown-elf",
         ];
 
         for target in targets.iter() {

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -1,12 +1,12 @@
 // This file defines all the identifier enums and target-aware logic.
 
 use crate::triple::{Endianness, PointerWidth, Triple};
+use alloc::borrow::Cow;
 use alloc::boxed::Box;
 use alloc::string::String;
 use core::fmt;
 use core::hash::{Hash, Hasher};
 use core::str::FromStr;
-use alloc::borrow::Cow;
 
 /// The "architecture" field, which in some cases also specifies a specific
 /// subarchitecture.
@@ -314,11 +314,9 @@ impl Aarch64Architecture {
 #[cfg_attr(feature = "rust_1_40", non_exhaustive)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[allow(missing_docs)]
-pub enum CleverArchitecture{
+pub enum CleverArchitecture {
     Clever,
     Clever1_0,
-    // clever1.1.. is valid to parse. 
-    CleverFuture(Cow<str>),
 }
 
 /// An enum for all 32-bit RISC-V architectures.
@@ -705,15 +703,11 @@ impl fmt::Display for Aarch64Architecture {
     }
 }
 
-impl fmt::Display for CleverArchitecture{
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result{
-        match self{
+impl fmt::Display for CleverArchitecture {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
             Self::Clever => f.write_str("clever"),
             Self::Clever1_0 => f.write_str("clever1.0"),
-            Self::CleverFuture(ver) => {
-                f.write_str("clever")?;
-                f.write_str(ver)
-            }
         }
     }
 }
@@ -891,16 +885,13 @@ impl FromStr for Aarch64Architecture {
     }
 }
 
-impl FromStr for CleverArchitecture{
+impl FromStr for CleverArchitecture {
     type Err = ();
-    fn from_str(s: &str) -> Result<Self, ()>{
-        match s{
+    fn from_str(s: &str) -> Result<Self, ()> {
+        match s {
             "clever" => Ok(Self::Clever),
             "clever1.0" => Ok(Self::Clever1_0),
-            x if x.starts_with("clever") => {
-                let x = &x[5..];
-                Ok(Self::CleverFuture(Cow::Owned(x.to_string())))
-            }
+            _ => Err(())
         }
     }
 }
@@ -1028,7 +1019,7 @@ impl FromStr for Architecture {
                     Mips32(mips32)
                 } else if let Ok(mips64) = Mips64Architecture::from_str(s) {
                     Mips64(mips64)
-                } else if let Ok(clever) = CleverArchitecture::from_str(s){
+                } else if let Ok(clever) = CleverArchitecture::from_str(s) {
                     Clever(clever)
                 } else {
                     return Err(());
@@ -1591,7 +1582,7 @@ mod tests {
             "x86_64-uwp-windows-msvc",
             "x86_64-wrs-vxworks",
             "xtensa-esp32-espidf",
-            "clever-unknown-elf"
+            "clever-unknown-elf",
         ];
 
         for target in targets.iter() {

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -1,7 +1,6 @@
 // This file defines all the identifier enums and target-aware logic.
 
 use crate::triple::{Endianness, PointerWidth, Triple};
-use alloc::borrow::Cow;
 use alloc::boxed::Box;
 use alloc::string::String;
 use core::fmt;
@@ -706,8 +705,8 @@ impl fmt::Display for Aarch64Architecture {
 impl fmt::Display for CleverArchitecture {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::Clever => f.write_str("clever"),
-            Self::Clever1_0 => f.write_str("clever1.0"),
+            CleverArchitecture::Clever => f.write_str("clever"),
+            CleverArchitecture::Clever1_0 => f.write_str("clever1.0"),
         }
     }
 }
@@ -891,7 +890,7 @@ impl FromStr for CleverArchitecture {
         match s {
             "clever" => Ok(Self::Clever),
             "clever1.0" => Ok(Self::Clever1_0),
-            _ => Err(())
+            _ => Err(()),
         }
     }
 }

--- a/src/triple.rs
+++ b/src/triple.rs
@@ -228,8 +228,9 @@ impl fmt::Display for Triple {
             // ad-hoc, and is just sufficient to handle the current set of recognized
             // triples.
             write!(f, "-{}", self.operating_system)?;
-        } else if matches!(self.architecture,Architecture::Clever(_)) && self.operating_system == OperatingSystem::Unknown{
-            write!(f, "-{}",self.vendor)?;
+        } else if self.architecture.is_clever() && self.operating_system == OperatingSystem::Unknown
+        {
+            write!(f, "-{}", self.vendor)?;
         } else {
             write!(f, "-{}-{}", self.vendor, self.operating_system)?;
         }

--- a/src/triple.rs
+++ b/src/triple.rs
@@ -228,6 +228,8 @@ impl fmt::Display for Triple {
             // ad-hoc, and is just sufficient to handle the current set of recognized
             // triples.
             write!(f, "-{}", self.operating_system)?;
+        } else if matches!(self.architecture,Architecture::Clever(_)) && self.operating_system == OperatingSystem::Unknown{
+            write!(f, "-{}",self.vendor)?;
         } else {
             write!(f, "-{}-{}", self.vendor, self.operating_system)?;
         }


### PR DESCRIPTION
This adds support for the `clever` architecture, including version specifiers. 

Clever-ISA is defined by <https://github.com/Clever-ISA/Clever-ISA> and the format of targets is defined by the toolchain recommendations technical document (specs/toolchain.md or referred to as D-toolchain).  This PR supports both the "bare" clever name specifier, as well as ones with a version suffix. The targets are also supported by the similar target parsing library, [target-tuples](https://crates.io/crates/target-tuples). 

The support is being added so I can add the architecture to a fork cranelift code generator, for the purposes of using it via rustc_codegen_cranelift. Proposing to upstream the modification to cranelift is a possibility depending on how well it goes. 