### PR TITLE
Add support for loongarch64 architecture

### DIFF
--- a/src/targets.rs
+++ b/src/targets.rs
@@ -24,6 +24,7 @@ pub enum Architecture {
     Hexagon,
     X86_32(X86_32Architecture),
     M68k,
+    LoongArch64,
     Mips32(Mips32Architecture),
     Mips64(Mips64Architecture),
     Msp430,
@@ -550,6 +551,7 @@ impl Architecture {
             | Bpfel
             | Hexagon
             | X86_32(_)
+            | LoongArch64
             | Mips64(Mips64Architecture::Mips64el)
             | Mips32(Mips32Architecture::Mipsel)
             | Mips32(Mips32Architecture::Mipsisa32r6el)
@@ -612,6 +614,7 @@ impl Architecture {
             | S390x
             | Sparc64
             | Sparcv9
+            | LoongArch64
             | Wasm64
             | Clever(_) => Ok(PointerWidth::U64),
         }
@@ -805,6 +808,7 @@ impl fmt::Display for Architecture {
             Bpfel => f.write_str("bpfel"),
             Hexagon => f.write_str("hexagon"),
             X86_32(x86_32) => x86_32.fmt(f),
+            LoongArch64 => f.write_str("loongarch64"),
             M68k => f.write_str("m68k"),
             Mips32(mips32) => mips32.fmt(f),
             Mips64(mips64) => mips64.fmt(f),
@@ -1002,6 +1006,7 @@ impl FromStr for Architecture {
             "bpfeb" => Bpfeb,
             "bpfel" => Bpfel,
             "hexagon" => Hexagon,
+            "loongarch64" => LoongArch64,
             "m68k" => M68k,
             "msp430" => Msp430,
             "nvptx64" => Nvptx64,
@@ -1484,6 +1489,7 @@ mod tests {
             "i686-uwp-windows-gnu",
             "i686-uwp-windows-msvc",
             "i686-wrs-vxworks",
+            "loongarch64-unknown-linux-gnu",
             "m68k-unknown-linux-gnu",
             "mips64el-unknown-linux-gnuabi64",
             "mips64el-unknown-linux-muslabi64",


### PR DESCRIPTION
The LoongArch architecture (LoongArch) is an Instruction Set Architecture (ISA) that has a RISC style.

Documentations:
ISA:
https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html
ABI:
https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html
More docs can be found at:
https://loongson.github.io/LoongArch-Documentation/README-EN.html