### PR TITLE
Use fully-qualified syntax in `triple!` for calling `from_str`

### DIFF
--- a/src/triple.rs
+++ b/src/triple.rs
@@ -401,7 +401,7 @@ impl Triple {
 #[macro_export]
 macro_rules! triple {
     ($str:tt) => {
-        target_lexicon::Triple::from_str($str).expect("invalid triple literal")
+        <$crate::Triple as core::str::FromStr>::from_str($str).expect("invalid triple literal")
     };
 }
 


### PR DESCRIPTION
This way the caller doesn't need to import `FromStr`.