### PR TITLE
Add `riscv32im-risc0-zkvm-elf` target (corresp. rust-lang/rust PR 117958)

### DIFF
--- a/src/targets.rs
+++ b/src/targets.rs
@@ -656,6 +656,7 @@ pub enum OperatingSystem {
     Wasi,
     Watchos,
     Windows,
+    Zkvm,
 }
 
 impl OperatingSystem {
@@ -702,6 +703,7 @@ impl OperatingSystem {
             Wasi => Cow::Borrowed("wasi"),
             Watchos => Cow::Borrowed("watchos"),
             Windows => Cow::Borrowed("windows"),
+            Zkvm => Cow::Borrowed("zkvm"),
         }
     }
 }
@@ -1414,6 +1416,7 @@ impl FromStr for OperatingSystem {
             "watchos" => Watchos,
             "windows" => Windows,
             "espidf" => Espidf,
+            "zkvm" => Zkvm,
             _ => return Err(()),
         })
     }
@@ -1646,6 +1649,7 @@ mod tests {
             "riscv32imc-esp-espidf",
             "riscv32imc-unknown-none-elf",
             "riscv32im-unknown-none-elf",
+            "riscv32im-risc0-zkvm",
             "riscv32i-unknown-none-elf",
             "riscv64gc-unknown-freebsd",
             "riscv64gc-unknown-linux-gnu",


### PR DESCRIPTION
This PR proposes adding the `riscv32im-risc0-zkvm-elf` target. Unlike the `zkasm` target which may be premature, the risc0 one has been used by developers, can be used to create ZK/blockchain applications for payments to email address (see https://pay.demos.bonsai.xyz/), and is currently undergoing the process of being part of Rust by satisfying the requirement of being a tier-3 target.

https://github.com/rust-lang/rust/pull/117958
(The remaining steps are mostly to sync up with the latest Rust main)

A formal document that describes this tier-3 target can also be found:
https://github.com/rust-lang/rust/blob/8db6f597169b32e7a970ffa66bec5e7dae35d8a8/src/doc/rustc/src/platform-support/riscv32im-risc0-zkvm-elf.md

The only change needed here is to add `zkvm` as a valid operating system. Picking `zkvm` as an operating system rather than an environment is to stay consistent with the Rust tier-3 target configuration as specified here:
https://github.com/rust-lang/rust/pull/117958/files#diff-9d4db4407bd3a1d92dca3c693fd1fce5b9b11cb5726fe92d18aa4d7bd65caae1R12

-----

I argue that adding this target into `target-lexicon` is timely, for two reasons.

- The target has been used in production and likely would become part of Rust soon.
- We already have developers that suffer from `target-lexicon` not knowing this target---a developer (https://twitter.com/NitanshuL) working on using `wasmer` https://docs.rs/wasmer/latest/wasmer/ would not be able to proceed with this library because `wasmer` uses `target-lexicon`, and `target-lexicon` refuses to be built in an architecture that it does not know (a build.rs thing).

> thread 'main' panicked at 'Invalid target name: 'riscv32im-risc0-zkvm-elf'', from target-lexicon-0.12.12/build.rs:52:54