### PR TITLE
Fix the `Target::pointer_width` value on x32 and ilp32 targets.

### DIFF
--- a/src/targets.rs
+++ b/src/targets.rs
@@ -355,6 +355,9 @@ impl Aarch64Architecture {
     // }
 
     /// Return the pointer bit width of this target's architecture.
+    ///
+    /// This function is only aware of the CPU architecture so it is not aware
+    /// of ilp32 ABIs.
     pub fn pointer_width(self) -> PointerWidth {
         match self {
             Aarch64Architecture::Aarch64 | Aarch64Architecture::Aarch64be => PointerWidth::U64,
@@ -868,6 +871,9 @@ impl Architecture {
     }
 
     /// Return the pointer bit width of this target's architecture.
+    ///
+    /// This function is only aware of the CPU architecture so it is not aware
+    /// of ilp32 and x32 ABIs.
     #[rustfmt::skip]
     pub fn pointer_width(self) -> Result<PointerWidth, ()> {
         use Architecture::*;


### PR DESCRIPTION
x32 and ilp32 are ABI variants on x86_64 and aarch64 platforms where pointers have 32-bit, even though the CPU architectures are 64-bit. Fix target-lexicon to correctly report the pointer width for these.

Fixes #97.