### PR TITLE
Fix the default binary format for most architectures to be ELF.

### DIFF
--- a/src/targets.rs
+++ b/src/targets.rs
@@ -1006,7 +1006,9 @@ pub(crate) fn default_binary_format(triple: &Triple) -> BinaryFormat {
         | OperatingSystem::Wasi
         | OperatingSystem::Unknown => match triple.architecture {
             Architecture::Wasm32 | Architecture::Wasm64 => BinaryFormat::Wasm,
-            _ => BinaryFormat::Unknown,
+            Architecture::Unknown => BinaryFormat::Unknown,
+            // Default to ELF, following `getDefaultFormat` in LLVM.
+            _ => BinaryFormat::Elf,
         },
         _ => BinaryFormat::Elf,
     }
@@ -1821,6 +1823,19 @@ mod tests {
     }
 
     #[test]
+    fn default_format_to_elf() {
+        let t = Triple::from_str("riscv64").expect("can't parse target");
+        assert_eq!(
+            t.architecture,
+            Architecture::Riscv64(Riscv64Architecture::Riscv64),
+        );
+        assert_eq!(t.vendor, Vendor::Unknown);
+        assert_eq!(t.operating_system, OperatingSystem::Unknown);
+        assert_eq!(t.environment, Environment::Unknown);
+        assert_eq!(t.binary_format, BinaryFormat::Elf);
+    }
+
+    #[test]
     fn thumbv7em_none_eabihf() {
         let t = Triple::from_str("thumbv7em-none-eabihf").expect("can't parse target");
         assert_eq!(
@@ -1915,7 +1930,7 @@ mod tests {
         );
         assert_eq!(t.operating_system, OperatingSystem::Unknown);
         assert_eq!(t.environment, Environment::Unknown);
-        assert_eq!(t.binary_format, BinaryFormat::Unknown);
+        assert_eq!(t.binary_format, BinaryFormat::Elf);
 
         assert_eq!(
             Triple::from_str("unknown-foo"),

--- a/src/triple.rs
+++ b/src/triple.rs
@@ -260,7 +260,19 @@ impl fmt::Display for Triple {
             }
         }
 
-        if self.binary_format != implied_binary_format {
+        if self.binary_format != implied_binary_format
+            || (self.binary_format != BinaryFormat::Unknown
+                && self.environment != Environment::Eabi
+                && self.environment != Environment::Eabihf
+                && self.environment != Environment::Sgx
+                && self.architecture != Architecture::Avr
+                && self.architecture != Architecture::Wasm32
+                && self.architecture != Architecture::Wasm64
+                && (self.operating_system == OperatingSystem::None_
+                    || self.operating_system == OperatingSystem::Unknown))
+        {
+            // As a special case, omit a non-default binary format for some
+            // targets which happen to exclude it.
             write!(f, "-{}", self.binary_format)?;
         }
         Ok(())

--- a/src/triple.rs
+++ b/src/triple.rs
@@ -275,8 +275,10 @@ fn show_binary_format_with_no_os(triple: &Triple) -> bool {
     }
 
     #[cfg(feature = "arch_zkasm")]
-    if triple.architecture == Architecture::ZkAsm {
-        return false;
+    {
+        if triple.architecture == Architecture::ZkAsm {
+            return false;
+        }
     }
 
     triple.environment != Environment::Eabi

--- a/src/triple.rs
+++ b/src/triple.rs
@@ -260,23 +260,33 @@ impl fmt::Display for Triple {
             }
         }
 
-        if self.binary_format != implied_binary_format
-            || (self.binary_format != BinaryFormat::Unknown
-                && self.environment != Environment::Eabi
-                && self.environment != Environment::Eabihf
-                && self.environment != Environment::Sgx
-                && self.architecture != Architecture::Avr
-                && self.architecture != Architecture::Wasm32
-                && self.architecture != Architecture::Wasm64
-                && (self.operating_system == OperatingSystem::None_
-                    || self.operating_system == OperatingSystem::Unknown))
-        {
+        if self.binary_format != implied_binary_format || show_binary_format_with_no_os(self) {
             // As a special case, omit a non-default binary format for some
             // targets which happen to exclude it.
             write!(f, "-{}", self.binary_format)?;
         }
         Ok(())
     }
+}
+
+fn show_binary_format_with_no_os(triple: &Triple) -> bool {
+    if triple.binary_format == BinaryFormat::Unknown {
+        return false;
+    }
+
+    #[cfg(feature = "arch_zkasm")]
+    if triple.architecture == Architecture::ZkAsm {
+        return false;
+    }
+
+    triple.environment != Environment::Eabi
+        && triple.environment != Environment::Eabihf
+        && triple.environment != Environment::Sgx
+        && triple.architecture != Architecture::Avr
+        && triple.architecture != Architecture::Wasm32
+        && triple.architecture != Architecture::Wasm64
+        && (triple.operating_system == OperatingSystem::None_
+            || triple.operating_system == OperatingSystem::Unknown)
 }
 
 impl FromStr for Triple {


### PR DESCRIPTION
Following the [logic in LLVM], make the binary format for most targets be ELF instead of Unknown. To preserve round-tripping for Rust target names, this requires some special-casing in the formatting code, but this isn't new; a lot of targets require special cases to round-trip properly.

[logic in LLVM]: https://github.com/llvm/llvm-project/blob/d3e7c4ce7a3d7f08cea02cba8f34c590a349688b/llvm/lib/TargetParser/Triple.cpp#L877