### PR TITLE
Parse the deployment target on all Apple target triples

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -24,7 +24,7 @@ mod tests {
     #[test]
     fn test_macos() {
         use super::*;
-        assert_eq!(OperatingSystem::host(), OperatingSystem::Darwin);
+        assert_eq!(OperatingSystem::host(), OperatingSystem::Darwin(None));
     }
 
     #[cfg(windows)]

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -630,7 +630,7 @@ impl Vendor {
 /// This is formatted as `"major.minor.patch"`.
 ///
 /// The size of the parts here are limited by Mach-O's `LC_BUILD_VERSION`.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[allow(missing_docs)]
 pub struct DeploymentTarget {
     pub major: u16,

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -764,6 +764,25 @@ impl OperatingSystem {
             XROS(deployment_target) => darwin_version("xros", deployment_target),
         }
     }
+
+    /// Whether the OS is similar to Darwin.
+    ///
+    /// This matches on any of:
+    /// - [Darwin](Self::Darwin)
+    /// - [iOS](Self::IOS)
+    /// - [macOS](Self::MacOSX)
+    /// - [tvOS](Self::TvOS)
+    /// - [visionOS](Self::VisionOS)
+    /// - [watchOS](Self::WatchOS)
+    /// - [xrOS](Self::XROS)
+    pub fn is_like_darwin(&self) -> bool {
+        use OperatingSystem::*;
+
+        match self {
+            Darwin(_) | IOS(_) | MacOSX(_) | TvOS(_) | VisionOS(_) | WatchOS(_) | XROS(_) => true,
+            _ => false,
+        }
+    }
 }
 
 /// The "environment" field, which specifies an ABI environment on top of the
@@ -1043,13 +1062,7 @@ pub(crate) fn default_binary_format(triple: &Triple) -> BinaryFormat {
             _ => BinaryFormat::Unknown,
         },
         OperatingSystem::Aix => BinaryFormat::Xcoff,
-        OperatingSystem::Darwin(_)
-        | OperatingSystem::IOS(_)
-        | OperatingSystem::MacOSX(_)
-        | OperatingSystem::VisionOS(_)
-        | OperatingSystem::WatchOS(_)
-        | OperatingSystem::TvOS(_)
-        | OperatingSystem::XROS(_) => BinaryFormat::Macho,
+        os if os.is_like_darwin() => BinaryFormat::Macho,
         OperatingSystem::Windows => BinaryFormat::Coff,
         OperatingSystem::Nebulet
         | OperatingSystem::Emscripten

--- a/src/triple.rs
+++ b/src/triple.rs
@@ -121,13 +121,7 @@ impl Triple {
     /// Return the default calling convention for the given target triple.
     pub fn default_calling_convention(&self) -> Result<CallingConvention, ()> {
         Ok(match self.operating_system {
-            OperatingSystem::Darwin(_)
-            | OperatingSystem::IOS(_)
-            | OperatingSystem::TvOS(_)
-            | OperatingSystem::MacOSX(_)
-            | OperatingSystem::WatchOS(_)
-            | OperatingSystem::VisionOS(_)
-            | OperatingSystem::XROS(_) => match self.architecture {
+            os if os.is_like_darwin() => match self.architecture {
                 Architecture::Aarch64(_) => CallingConvention::AppleAarch64,
                 _ => CallingConvention::SystemV,
             },

--- a/src/triple.rs
+++ b/src/triple.rs
@@ -121,11 +121,13 @@ impl Triple {
     /// Return the default calling convention for the given target triple.
     pub fn default_calling_convention(&self) -> Result<CallingConvention, ()> {
         Ok(match self.operating_system {
-            OperatingSystem::Darwin
-            | OperatingSystem::Ios
-            | OperatingSystem::Tvos
-            | OperatingSystem::MacOSX { .. }
-            | OperatingSystem::Watchos => match self.architecture {
+            OperatingSystem::Darwin(_)
+            | OperatingSystem::IOS(_)
+            | OperatingSystem::TvOS(_)
+            | OperatingSystem::MacOSX(_)
+            | OperatingSystem::WatchOS(_)
+            | OperatingSystem::VisionOS(_)
+            | OperatingSystem::XROS(_) => match self.architecture {
                 Architecture::Aarch64(_) => CallingConvention::AppleAarch64,
                 _ => CallingConvention::SystemV,
             },


### PR DESCRIPTION
Also allow it to be optional, or partially specified.

This is a breaking change.

I've chosen to keep `Darwin` as a separate OS, since it seems like in https://github.com/bytecodealliance/target-lexicon/issues/111#issuecomment-2388418787 that this crate wants to focus on LLVM target triples.

Another solution would've been to merge it into `OperatingSystem::MacOSX`, and just ignore that `"darwin"` doesn't technically mean that (though it is likely to in practice). If we chose this solution (which would be focusing more on `rustc` targets), I would probably not want to parse the version at all, and just ignore it instead.