### PR TITLE
Make it clear in docs that we parse LLVM triples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "target-lexicon"
 version = "0.12.16"
 authors = ["Dan Gohman <sunfish@mozilla.com>"]
-description = "Targeting utilities for compilers and related tools"
+description = "LLVM target triple types"
 documentation = "https://docs.rs/target-lexicon/"
 readme = "README.md"
 keywords = ["target", "host", "triple", "compiler", "jit"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 This is a library for managing targets for compilers and related tools.
 
-Currently, the main feature is support for decoding "triples", which
+Currently, the main feature is support for decoding [LLVM "triples"], which
 are strings that identify a particular target configuration. They're named
 "triples" because historically they contained three fields, though over time
 they've added additional fields. This library provides a `Triple` struct
@@ -14,7 +14,11 @@ pointer bit width, and binary format.
 And, `Triple` and the enum types have `host()` constructors, for targeting
 the host.
 
-It supports all triples currently used by rustc and rustup.
+It somewhat supports reading triples currently used by `rustc` and rustup,
+though beware that the mapping between `rustc` and LLVM triples is not
+one-to-one.
 
 It does not support reading JSON target files itself. To use it with a JSON
 target file, construct a `Triple` using the value of the "llvm-target" field.
+
+[LLVM "triples"]: https://clang.llvm.org/docs/CrossCompilation.html#target-triple

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! Target triple support.
+//! LLVM target triple types.
 
 #![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
 #![warn(unused_import_braces)]

--- a/src/triple.rs
+++ b/src/triple.rs
@@ -78,8 +78,8 @@ pub enum CallingConvention {
     AppleAarch64,
 }
 
-/// A target "triple". Historically such things had three fields, though they've
-/// added additional fields over time.
+/// An LLVM target "triple". Historically such things had three fields, though
+/// they've added additional fields over time.
 ///
 /// Note that `Triple` doesn't implement `Default` itself. If you want a type
 /// which defaults to the host triple, or defaults to unknown-unknown-unknown,
@@ -291,6 +291,10 @@ fn show_binary_format_with_no_os(triple: &Triple) -> bool {
 impl FromStr for Triple {
     type Err = ParseError;
 
+    /// Parse a triple from an LLVM target triple.
+    ///
+    /// This may also be able to parse `rustc` target triples, though support
+    /// for that is secondary.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if let Some(triple) = Triple::special_case_from_str(s) {
             return Ok(triple);


### PR DESCRIPTION
Fixes https://github.com/bytecodealliance/target-lexicon/issues/111.