### PR TITLE
feat: make `DeploymentTarget` public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,9 +33,9 @@ pub use self::data_model::{CDataModel, Size};
 pub use self::host::HOST;
 pub use self::parse_error::ParseError;
 pub use self::targets::{
-    Aarch64Architecture, Architecture, ArmArchitecture, BinaryFormat, CustomVendor, Environment,
-    Mips32Architecture, Mips64Architecture, OperatingSystem, Riscv32Architecture,
-    Riscv64Architecture, Vendor, X86_32Architecture,
+    Aarch64Architecture, Architecture, ArmArchitecture, BinaryFormat, CustomVendor,
+    DeploymentTarget, Environment, Mips32Architecture, Mips64Architecture, OperatingSystem,
+    Riscv32Architecture, Riscv64Architecture, Vendor, X86_32Architecture,
 };
 pub use self::triple::{CallingConvention, Endianness, PointerWidth, Triple};
 


### PR DESCRIPTION
Otherwise you can't pattern match it on `OperatingSystem::Darwin()` etc.