### PR TITLE
add Cygwin support

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -13,6 +13,13 @@ mod tests {
         assert_eq!(OperatingSystem::host(), OperatingSystem::Aix);
     }
 
+    #[cfg(target_os = "cygwin")]
+    #[test]
+    fn test_cygwin() {
+        use super::*;
+        assert_eq!(OperatingSystem::host(), OperatingSystem::Cygwin);
+    }
+
     #[cfg(target_os = "linux")]
     #[test]
     fn test_linux() {

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -656,6 +656,7 @@ pub enum OperatingSystem {
     Bitrig,
     Cloudabi,
     Cuda,
+    Cygwin,
     /// The general [Darwin][darwin-wiki] core OS.
     ///
     /// Generally, `-mmacosx-version-min=...` or similar flags are required by
@@ -731,6 +732,7 @@ impl OperatingSystem {
             Bitrig => Cow::Borrowed("bitrig"),
             Cloudabi => Cow::Borrowed("cloudabi"),
             Cuda => Cow::Borrowed("cuda"),
+            Cygwin => Cow::Borrowed("cygwin"),
             Darwin(deployment_target) => darwin_version("darwin", deployment_target),
             Dragonfly => Cow::Borrowed("dragonfly"),
             Emscripten => Cow::Borrowed("emscripten"),
@@ -1542,6 +1544,7 @@ impl FromStr for OperatingSystem {
             "bitrig" => Bitrig,
             "cloudabi" => Cloudabi,
             "cuda" => Cuda,
+            "cygwin" => Cygwin,
             "dragonfly" => Dragonfly,
             "emscripten" => Emscripten,
             "freebsd" => Freebsd,
@@ -1892,6 +1895,7 @@ mod tests {
             "x86_64-linux-kernel", // Changed to x86_64-unknown-none-linuxkernel in 1.53.0
             "x86_64-apple-macosx",
             "x86_64-apple-macosx10.7.0",
+            "x86_64-pc-cygwin",
             "x86_64-pc-solaris",
             "x86_64-pc-windows-gnu",
             "x86_64-pc-windows-gnullvm",


### PR DESCRIPTION
introduces new `Cygwin` OS, which is technically Unix (Linux) API under Windows. you may check https://cygwin.com on details what's this. the `x86_64-pc-cygwin` target has been added to Rust recently 