### PR TITLE
feat: add ohoseabi abi

### DIFF
--- a/src/targets.rs
+++ b/src/targets.rs
@@ -872,6 +872,7 @@ pub enum Environment {
     Spe,
     Threads,
     Ohos,
+    Ohoseabi
 }
 
 impl Environment {
@@ -915,6 +916,7 @@ impl Environment {
             Spe => Cow::Borrowed("spe"),
             Threads => Cow::Borrowed("threads"),
             Ohos => Cow::Borrowed("ohos"),
+            Ohoseabi => Cow::Borrowed("ohoseabi"),
         }
     }
 }
@@ -1708,6 +1710,7 @@ impl FromStr for Environment {
             "spe" => Spe,
             "threads" => Threads,
             "ohos" => Ohos,
+            "ohoseabi" => Ohoseabi,
             _ => return Err(()),
         })
     }


### PR DESCRIPTION
This is an adaption to follow zig and zigbuild. That can help us to use zig-build for OpenHarmony.

Zig changed `arm-linux-ohos` to `arm-linux-ohoseabi` since `0.15`.  For older zigbuild, it generate the following code:
```sh
#!/bin/sh
exec "/Users/ranger/.cargo/bin/cargo-zigbuild" zig c++ -- -g -mcpu=generic+v7a+vfp3-d32+thumb2-neon -target arm-linux-ohos "$@"
```

But it can't use for zig@0.15, it must be:

```sh
#!/bin/sh
exec "/Users/ranger/.cargo/bin/cargo-zigbuild" zig c++ -- -g -mcpu=generic+v7a+vfp3-d32+thumb2-neon -target arm-linux-ohoseabi "$@"
```

So we need to add new abi for OHOS and then we can add some adaption code for zigbuild.