### PR TITLE
Add Arm64_32 variant to Aarch64Architecture for arm64_32-apple-watchos

### DIFF
--- a/src/targets.rs
+++ b/src/targets.rs
@@ -116,6 +116,11 @@ pub enum ArmArchitecture {
 pub enum Aarch64Architecture {
     Aarch64,
     Aarch64be,
+    /// AArch64 with ILP32 ABI (32-bit pointers, 64-bit registers and ISA).
+    /// Used by Apple Watch from Series 4 onward via the `arm64_32-apple-watchos`
+    /// target. The `_32` suffix is part of Apple/LLVM's architecture name.
+    #[allow(non_camel_case_types)]
+    Arm64_32,
 }
 
 // #[cfg_attr(feature = "rust_1_40", non_exhaustive)]
@@ -352,7 +357,9 @@ impl Aarch64Architecture {
     /// Test if this architecture uses the Thumb instruction set.
     pub fn is_thumb(self) -> bool {
         match self {
-            Aarch64Architecture::Aarch64 | Aarch64Architecture::Aarch64be => false,
+            Aarch64Architecture::Aarch64
+            | Aarch64Architecture::Aarch64be
+            | Aarch64Architecture::Arm64_32 => false,
         }
     }
 
@@ -363,10 +370,13 @@ impl Aarch64Architecture {
     /// Return the pointer bit width of this target's architecture.
     ///
     /// This function is only aware of the CPU architecture so it is not aware
-    /// of ilp32 ABIs.
+    /// of ilp32 ABIs in general — but Apple's `arm64_32` is treated as its own
+    /// architecture variant rather than via an environment, so it does report
+    /// `U32` here.
     pub fn pointer_width(self) -> PointerWidth {
         match self {
             Aarch64Architecture::Aarch64 | Aarch64Architecture::Aarch64be => PointerWidth::U64,
+            Aarch64Architecture::Arm64_32 => PointerWidth::U32,
         }
     }
 
@@ -375,6 +385,7 @@ impl Aarch64Architecture {
         match self {
             Aarch64Architecture::Aarch64 => Endianness::Little,
             Aarch64Architecture::Aarch64be => Endianness::Big,
+            Aarch64Architecture::Arm64_32 => Endianness::Little,
         }
     }
 
@@ -385,6 +396,7 @@ impl Aarch64Architecture {
         match self {
             Aarch64 => Cow::Borrowed("aarch64"),
             Aarch64be => Cow::Borrowed("aarch64_be"),
+            Arm64_32 => Cow::Borrowed("arm64_32"),
         }
     }
 }
@@ -1260,6 +1272,7 @@ impl FromStr for Aarch64Architecture {
             "aarch64" => Aarch64,
             "arm64" => Aarch64,
             "aarch64_be" => Aarch64be,
+            "arm64_32" => Arm64_32,
             _ => return Err(()),
         })
     }
@@ -1786,7 +1799,7 @@ mod tests {
             "aarch64-unknown-uefi",
             "aarch64-uwp-windows-msvc",
             "aarch64-wrs-vxworks",
-            //"arm64_32-apple-watchos", // TODO
+            "arm64_32-apple-watchos",
             //"arm64e-apple-darwin", // TODO
             "amdgcn-amd-amdhsa",
             "amdgcn-amd-amdhsa-amdgiz",


### PR DESCRIPTION
## Summary

Adds a third `Arm64_32` variant to `Aarch64Architecture` so the
`arm64_32-apple-watchos` Rust target triple round-trips through
`Triple::from_str` / `Display`.

Apple Watch Series 4+ ships an AArch64 ISA with an ILP32 ABI: 64-bit
registers, 32-bit pointers. Apple/LLVM treat the arch token as
`arm64_32` (not as a `gnu_ilp32`-style environment qualifier the way
Linux does). The current crate exposes only `Aarch64` and `Aarch64be`,
both hardcoded to `pointer_width = U64`, so any consumer that calls
`Triple::from_str("arm64_32-apple-watchos")` panics with
`Invalid target name`. There is a `// TODO` placeholder for this triple
in the `roundtrip_known_triples` test that this PR un-comments.

## Why this matters

Without this patch nothing in the bytecodealliance ecosystem can build
for arm64_32-apple-watchos — `wasmtime` / `cranelift` consume
`target-lexicon` transitively through `wasmtime-environ` and others,
and their build scripts call `Triple::from_str(env!(\"TARGET\"))`. The
panic surfaces during `cargo build --target arm64_32-apple-watchos`
before any target-side code is even attempted.

This is the same pattern as the existing `aarch64-apple-watchos` /
`aarch64-apple-watchos-sim` entries — those are aarch64 with U64
pointers; arm64_32 is the same ISA with U32 pointers.

## What changed

1. New variant `Aarch64Architecture::Arm64_32` (with a doc comment
   explaining the Apple/LLVM naming convention).
2. `pointer_width()` returns `U32` for the new variant, `U64` for the
   existing two — preserving the doc note that this method is
   normally arch-only and ILP32-blind, with an explicit carve-out for
   arm64_32 (which Apple models as its own arch, not via environment).
3. `endianness()` returns `Little`.
4. `into_str()` returns `\"arm64_32\"` so `Display` / `to_string()`
   round-trip the original token.
5. `is_thumb()` returns `false` (consistent with the other AArch64
   variants).
6. `Aarch64Architecture::FromStr` accepts `\"arm64_32\"`.
7. The known-triples test list at \`src/targets.rs\` un-comments the
   `\"arm64_32-apple-watchos\"` entry that was already there as a
   `// TODO` placeholder.

## Test

`cargo test` — all 14 tests pass, including
`roundtrip_known_triples` which exercises the new triple.

## Verified end-to-end on real hardware

This patch is one of three needed to build wasmtime+Pulley as a static
library for `arm64_32-apple-watchos`. The combined stack has been
deployed to a real Apple Watch SE 2 (S8 SoC, watchOS 11.6.2), where
all 11 wasm benchmarks (recursive fib, tail-call fib, sieve, CRC32,
two SIMD matmuls, convolution, audio-DSP, bulk-memory, call_indirect)
run with byte-identical results to their host references.